### PR TITLE
Add integration test that was formerly in lira repo

### DIFF
--- a/test/10x_notification_dev.json
+++ b/test/10x_notification_dev.json
@@ -1,0 +1,9 @@
+{
+  "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
+  "subscription_id": "3e3e176b-629f-46ea-b01d-e36bd650dc54",
+  "match": {
+    "bundle_uuid": "347f5080-65e1-495d-9051-c9c8c26dfc4a",
+    "bundle_version": "2017-09-30T174724.242288Z"
+  }
+}
+

--- a/test/await_workflow_completion.py
+++ b/test/await_workflow_completion.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+from datetime import datetime
+from datetime import timedelta
+import requests
+import subprocess
+import time
+
+failed_statuses = ['Failed', 'Aborted', 'Aborting']
+
+def run(args):
+    cromwell_user, cromwell_pw = extract_credentials(args.secrets_file)
+    workflow_ids = args.workflow_ids.split(',')
+    workflow_names = args.workflow_names.split(',')
+    start = datetime.now()
+    timeout = timedelta(minutes=int(args.timeout_minutes))
+    while True:
+        if datetime.now() - start > timeout:
+            msg = 'Unfinished workflows after {0} minutes.'
+            raise Exception(msg.format(timeout))
+        statuses = get_statuses(workflow_names, workflow_ids, args.cromwell_url, cromwell_user, cromwell_pw)
+        all_succeeded = True
+        for i, status in enumerate(statuses):
+            if status in failed_statuses:
+                raise Exception('Stopping because {0} workflow {1} {2}'.format(workflow_names[i], workflow_ids[i], status))
+            elif status != 'Succeeded':
+                all_succeeded = False
+        if all_succeeded:
+            print('All workflows succeeded!')
+            break
+        else:
+            time.sleep(10)
+
+def get_statuses(names, ids, cromwell_url, user, pw):
+    statuses = []
+    for i, name in enumerate(names):
+        id = ids[i]
+        full_url = cromwell_url + '/api/workflows/v1/{0}/status'.format(id)
+        response = requests.get(full_url, auth=requests.auth.HTTPBasicAuth(user, pw))
+        if response.status_code != 200:
+            msg = 'Could not get status for {0} workflow {1}. Cromwell at {2} returned status {3}'
+            print(msg.format(name, id, cromwell_url, status_code))
+            statuses.append('Unknown')
+        else:
+            response_json = response.json()
+            status = response_json['status']
+            statuses.append(status)
+            print('{0} workflow {1}: {2}'.format(name, id, status))
+    return statuses
+
+def extract_credentials(secrets_file):
+    with open(secrets_file) as f:
+        secrets = json.load(f)
+        return secrets['cromwell_user'], secrets['cromwell_password']
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--workflow_ids')
+    parser.add_argument('--workflow_names')
+    parser.add_argument('--cromwell_url')
+    parser.add_argument('--secrets_file')
+    parser.add_argument('--timeout_minutes')
+    args = parser.parse_args()
+    run(args)

--- a/test/configtemplate.json
+++ b/test/configtemplate.json
@@ -1,0 +1,22 @@
+{
+  "cromwell_url": "https://cromwell.mint-{env}.broadinstitute.org/api/workflows/v1",
+  "MAX_CONTENT_LENGTH": 10000,
+  "wdls": [
+    {
+      "subscription_id": "{10x_subscription_id}",
+      "workflow_name": "Wrapper10xCount",
+      "wdl_link": "gs://broad-dsde-mint-{env}-pipelines/10x/{10x_version}/infrastructure/{pipeline_tools_version}/wrapper.wdl",
+      "wdl_deps_link": "gs://broad-dsde-mint-{env}-pipelines/10x/{10x_version}/infrastructure/{pipeline_tools_version}/dependencies.zip",
+      "wdl_default_inputs_link": "gs://broad-dsde-mint-{env}-pipelines/10x/{10x_version}/infrastructure/{pipeline_tools_version}/static_inputs.json",
+      "options_link": "gs://broad-dsde-mint-{env}-pipelines/10x/{10x_version}/infrastructure/{pipeline_tools_version}/options.json"
+    },
+    {
+      "subscription_id": "{ss2_subscription_id}",
+      "workflow_name": "WrapperSs2RsemSingleSample",
+      "wdl_link": "gs://broad-dsde-mint-{env}-pipelines/ss2/{ss2_version}/infrastructure/{pipeline_tools_version}/wrapper.wdl",
+      "wdl_deps_link": "gs://broad-dsde-mint-{env}-pipelines/ss2/{ss2_version}/infrastructure/{pipeline_tools_version}/dependencies.zip",
+      "wdl_default_inputs_link": "gs://broad-dsde-mint-{env}-pipelines/ss2/{ss2_version}/infrastructure/{pipeline_tools_version}/static_inputs.json",
+      "options_link": "gs://broad-dsde-mint-{env}-pipelines/ss2/{ss2_version}/infrastructure/{pipeline_tools_version}/options.json"
+    }
+  ]
+}

--- a/test/current_deployed_pipeline_version.py
+++ b/test/current_deployed_pipeline_version.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+Parses the TSV file {mint_deployment_dir}/{env}.tsv and returns
+the version from the first line in the column named {pipeline_name}.
+For example, given the following TSV:
+10x	ss2
+1.0.0	2.0.0
+0.9.3	1.2.3
+
+If pipeline_name is 10x, returns "1.0.0".
+If pipeline_name is ss2, returns "2.0.0".
+
+"""
+
+import argparse
+import csv
+
+def run(pipeline_name, mint_deployment_dir, env):
+    with open('{0}/{1}.tsv'.format(mint_deployment_dir, env)) as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        row = reader.next()
+        print(row[pipeline_name])
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--pipeline_name', required=True)
+    parser.add_argument('--mint_deployment_dir', required=True)
+    parser.add_argument('--env', required=True)
+    args = parser.parse_args()
+    run(args.pipeline_name, args.mint_deployment_dir, args.env)

--- a/test/dev_config.json
+++ b/test/dev_config.json
@@ -1,0 +1,5 @@
+{
+  "env": "dev",
+  "10x_subscription_id": "3e3e176b-629f-46ea-b01d-e36bd650dc54",
+  "ss2_subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c"
+}

--- a/test/dev_secrets.json
+++ b/test/dev_secrets.json
@@ -1,0 +1,5 @@
+{
+  "notification_token": "test",
+  "cromwell_user": "test",
+  "cromwell_password": "test"
+}

--- a/test/get_latest_release.py
+++ b/test/get_latest_release.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+import argparse
+import requests
+import re
+
+class Tag:
+    def __init__(self, major, minor, patch):
+        self.v = [major, minor, patch]
+        self.string = '{0}.{1}.{2}'.format(self.v[0], self.v[1], self.v[2])
+
+    def __str__(self):
+        return self.string
+
+    def __eq__(self, other):
+        return self.string == other.string
+
+    def __gt__(self, other):
+        for s, o in zip(self.v, other.v):
+            if s < o:
+                return False
+            if s > o:
+                return True
+        return False
+
+def run(repo):
+    url = 'https://api.github.com/repos/{0}/git/refs/tags/'.format(repo) 
+    response = requests.get(url)
+    if response.status_code != 200:
+        raise ValueError('Return code was {0} for {1}, message:\n'.format(response.status_code, url, response.json()))
+    
+    p = re.compile(r'^(\d+)\.(\d+)\.(\d+)$')
+    tags = []
+    max_tag = Tag(0, 0, 0)
+    for tag_object in response.json():
+        tag_str = tag_object['ref'][10:]
+        m = p.match(tag_str)
+        if m:
+            tag = Tag(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+            if tag > max_tag:
+                max_tag = tag
+    print(max_tag)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--repo')
+    args = parser.parse_args()
+    run(args.repo)

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+
+# This script carries out the following steps:
+# 1. Clone Lira if needed
+# 2. Get pipeline-tools version
+# 3. Build or pull Lira image
+# 4. Get pipeline versions
+# 5. Render config.json
+# 6. Start Lira
+# 7. Send in notification
+# 8. Poll Cromwell for completion
+# 9. Stop Lira
+
+# This script currently only works when run locally on a developer's machine,
+# but is designed to be easy to adapt to running on a Jenkins or Travis VM.
+#
+# In addition to the parameters specified below, this script expects the following
+# files to be available:
+# -configtemplate.json, template for Lira config, will be rendered by this script
+# -${env}_config.json: environment config json file (contains environment-specific Lira config)
+# -${env}_secrets.json file (contains secrets for Lira)
+# 
+# The following parameters are required. 
+# Versions can be a branch name, tag, or commit hash
+#
+# env
+# The environment to use -- affects Cromwell url, buckets, Lira config.
+# When running from a PR, this will always be int. When running locally,
+# the developer can choose dev or int.
+#
+# mint_deployment_dir
+# Local directory where deployment TSVs can be found. Later, we'll
+# create a repo for this, and this script will be modified to look there.
+#
+# lira_mode and lira_version
+# The lira_mode param can be "local", "image" or "github".
+# If "local" is specified, a local copy of the Lira code is used and
+# lira_version is ignored. If "image" is specified, this script will pull and run
+# a particular version of the Lira docker image specified by lira_version.
+# TODO: Modify so that if lira_mode == "image" and lira_version == "deployed",
+# then the script will use the currently deployed image in env.
+# Running in "github" mode is not fully implemented yet, but is intended to clone
+# the Lira repo and check out a specific branch, tag, or commit to use, specified
+# by lira_version.
+#
+# pipeline_tools_mode and pipeline_tools_version
+# Currently, pipeline_tools_mode is ignored and pipeline_tools_version is extracted
+# from the deployment TSV.
+# TODO: Modify so that if mode is "local", then a local copy of the repo is used,
+# with the path to the repo specified in pipeline_tools_version.
+# TODO: Modify so that if mode is "github", then the script configures Lira to read the
+# wrapper WDLS from GitHub and use version pipeline_tools_version. Also, if lira_mode
+# is "local", then it will get built using that pipeline_tools_version. If pipeline_tools_version
+# is "current", then the deployment TSV is consulted to find and use the currently deployed
+# version of the wrapper WDLs.
+#
+# tenx_mode and tenx_version
+# Mode is required to be "current" right now and tenx_version is ignored.
+# The script will check the deployment TSV to find the currently deployed version of
+# the 10x pipeline.
+#
+# ss2_mode and ss2_version
+# Mode is required to be "current" right now and ss2_version is ignored.
+# The script will check the deployment TSV to find the currently deployed version of
+# the Smart-seq2 pipeline.
+
+set -e
+
+env=$1
+mint_deployment_dir=$2
+lira_mode=$3
+lira_version=$4
+pipeline_tools_mode=$5
+pipeline_tools_version=$6
+tenx_mode=$7
+tenx_version=$8
+ss2_mode=$9
+ss2_version=${10}
+
+work_dir=$(pwd)
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# 1. Clone Lira if needed 
+# TODO: Create a repo for integration_test.sh to go in, so that we
+# can run in github mode. Currently we have to run in lira local mode.
+lira_dir=$script_dir/../
+
+# 2. Get pipeline-tools version
+# TODO: Uncomment condition below once we have Lira reading wrapper WDLs from pipeline-tools repo
+#if [ $pipeline_tools_mode == "github" ] && [ $pipeline_tools_version == "current" ]; then
+  pipeline_tools_version=$(python $script_dir/current_deployed_pipeline_version.py \
+                    --mint_deployment_dir $mint_deployment_dir \
+                    --env $env \
+                    --pipeline_name pipeline_tools)
+  echo "pipeline_tools_version: $pipeline_tools_version"
+#fi
+
+# 3. Build or pull Lira image
+if [ $lira_mode == "image" ]; then
+  if [ $lira_version == "latest" ]; then
+    lira_image_version=$(python $script_dir/get_latest_release.py HumanCellAtlas/secondary-analysis)
+  else
+    lira_image_version=$lira_version
+  fi
+  docker pull humancellatlas/secondary-analysis:$lira_image_version
+elif [ $lira_mode == "local" ] || [ $lira_mode == "github" ]; then
+  lira_image_version=$lira_version
+  echo "Building Lira version: $lira_image_version"
+  cd $lira_dir
+  docker build -t humancellatlas/secondary-analysis:$lira_image_version .
+  cd -
+fi
+
+# 4. Get deployed pipeline versions to use
+# (TODO: Create mint-deployment repo and use it here)
+if [ $tenx_mode == "current" ]; then
+  tenx_version=$(python $script_dir/current_deployed_pipeline_version.py \
+                    --mint_deployment_dir $mint_deployment_dir \
+                    --env $env \
+                    --pipeline_name 10x)
+  echo "10x version: $tenx_version"
+else
+  "Only tenx_mode==current is supported"
+fi
+if [ $ss2_mode == "current" ]; then
+  ss2_version=$(python $script_dir/current_deployed_pipeline_version.py \
+                    --mint_deployment_dir $mint_deployment_dir \
+                    --env $env \
+                    --pipeline_name ss2)
+  echo "ss2 version: $ss2_version"
+else
+  "Only ss2_mode==current is supported"
+fi
+
+# 5. Render config.json
+# (TODO: Use Henry's script here)
+# TODO: use config file from config repo
+# dev_secrets.json will come from Vault eventually
+echo "Rendering Lira config"
+python $script_dir/render_lira_config.py \
+    --template_file configtemplate.json \
+    --env_config_file ${env}_config.json \
+    --secrets_file ${env}_secrets.json \
+    --10x_version $tenx_version \
+    --ss2_version $ss2_version \
+    --pipeline_tools_version $pipeline_tools_version > config.json
+
+# 6. Start Lira
+echo "Starting Lira docker image"
+lira_image_id=$(docker run \
+                -p 8080:8080 \
+                -d \
+                -e listener_config=/etc/secondary-analysis/config.json \
+                -e GOOGLE_APPLICATION_CREDENTIALS=/etc/secondary-analysis/bucket-reader-key.json \
+                -v $work_dir:/etc/secondary-analysis \
+                humancellatlas/secondary-analysis:$lira_image_version)
+
+# 7. Send in notifications
+# TODO: Check in notifications to repo where integration_test.sh will live so they are accessible outside Lira repo
+echo "Sending in notifications"
+virtualenv integration-test-env
+source integration-test-env/bin/activate
+pip install requests
+tenx_workflow_id=$(python $script_dir/send_notification.py \
+                  --lira_url "http://localhost:8080/notifications" \
+                  --secrets_file ${env}_secrets.json \
+                  --notification $lira_dir/test/10x_notification_${env}.json)
+ss2_workflow_id=$(python $script_dir/send_notification.py \
+                  --lira_url "http://localhost:8080/notifications" \
+                  --secrets_file ${env}_secrets.json \
+                  --notification $lira_dir/test/ss2_notification_${env}.json)
+echo "tenx_workflow_id: $tenx_workflow_id"
+echo "ss2_workflow_id: $ss2_workflow_id"
+
+# 8. Poll for completion
+echo "Awaiting workflow completion"
+python $script_dir/await_workflow_completion.py \
+  --workflow_ids $ss2_workflow_id,$tenx_workflow_id \
+  --workflow_names ss2,10x \
+  --cromwell_url https://cromwell.mint-$env.broadinstitute.org \
+  --secrets_file ${env}_secrets.json \
+  --timeout_minutes 20
+
+# 9. Stop listener
+echo "Stopping Lira"
+docker stop $lira_image_id

--- a/test/mint-deployment/dev.tsv
+++ b/test/mint-deployment/dev.tsv
@@ -1,0 +1,3 @@
+10x	ss2	pipeline_tools
+fake_10x_branch	fake_ss2_branch	fake_infra_branch
+old_fake_10x_branch	old_fake_ss2_branch	fake_infra_branch

--- a/test/render_lira_config.py
+++ b/test/render_lira_config.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import re
+
+def run(args):
+    with open(args.env_config_file) as f:
+        env_config = json.load(f)
+    with open(args.secrets_file) as f:
+        secrets_config = json.load(f)
+
+    with open(args.template_file) as f:
+        s = f.read()
+
+    params_dict = vars(args)
+    params_dict.update(env_config)
+    for k, v in params_dict.items():
+        s = s.replace('{{{0}}}'.format(k), v)
+    config = json.loads(s)
+    config.update(secrets_config)
+    print(json.dumps(config, indent=2, sort_keys=True))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--template_file')
+    parser.add_argument('--env_config_file')
+    parser.add_argument('--secrets_file')
+    parser.add_argument('--pipeline_tools_version')
+    parser.add_argument('--10x_version')
+    parser.add_argument('--ss2_version')
+    args = parser.parse_args()
+    run(args)

--- a/test/send_notification.py
+++ b/test/send_notification.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import requests
+
+def run(args):
+    with open(args.notification) as f:
+        notification = json.load(f)
+
+    with open(args.secrets_file) as f:
+        secrets = json.load(f)
+        token = secrets['notification_token']
+        full_url = args.lira_url + '?auth={0}'.format(token)
+
+    response = requests.post(full_url, json=notification)    
+    if response.status_code == 200:
+        response_json = response.json()
+        workflow_id = response_json['id']
+        print(workflow_id)
+    else:
+        msg = 'Unexpected response code {0} when sending notification {1} to url {2}: \n{3}'
+        raise ValueError(msg.format(response.status_code, args.notification, args.lira_url, response.text))
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--lira_url')
+    parser.add_argument('--secrets_file')
+    parser.add_argument('--notification')
+    args = parser.parse_args()
+    run(args)

--- a/test/ss2_notification_dev.json
+++ b/test/ss2_notification_dev.json
@@ -1,0 +1,9 @@
+{
+  "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
+  "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c",
+  "match": {
+    "bundle_uuid": "6db5c9af-9559-4bcc-bf14-50c9ae1c7566",
+    "bundle_version": "2017-09-21T172005.725867Z"
+  }
+}
+


### PR DESCRIPTION
This integration was merged into Lira today, but as part of repo reorganization, it makes more sense for the integration test to be in this repo rather than tying it to one of the components being tested.

This PR copies the files added to Lira here https://github.com/HumanCellAtlas/lira/pull/33, without making any changes.