### PR TITLE
Add script for getting new TLS certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:17.04
+
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get -y install software-properties-common && \
+    apt-get -y install --no-install-recommends \
+    python3.6 \
+    python3-pip \
+    python3-setuptools \
+    python3-wheel && \
+    add-apt-repository ppa:certbot/certbot && \
+    apt-get update && \
+    apt-get -y install --no-install-recommends \
+    vim \
+    git \
+    curl \
+    certbot
+
+RUN mkdir /certs
+WORKDIR /certs
+
+RUN pip3 install awscli --upgrade && \
+    git clone https://github.com/jed/certbot-route53.git && \
+    chmod u+x certbot-route53/certbot-route53.sh

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,34 @@
+This directory contains get_certs.sh, for getting a new TLS certificate.
+The script builds the docker image in the root of this repo, then runs
+a command inside it to renew a certificate using certbot.
+
+Requirements
+------------
+The docker container uses aws cli commands, which require credentials
+to be passed into the container via environment variables.
+
+You must set the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment
+variables before running the script, to authenticate as a user with 
+permissions to edit our DNS records.
+
+For example:
+```
+export AWS_ACCESS_KEY_ID=foo
+export AWS_SECRET_ACCESS_KEY=bar
+```
+
+Usage
+-----
+```
+bash get_certs.sh work_dir domain
+```
+where work_dir is the directory you'd like certificate to be written to
+and domain is the domain you'd like to obtain a certificate for
+
+Example
+-------
+```
+bash get_certs.sh $(pwd) pipelines.dev.data.humancellatlas.org
+```
+This will obtain a certificate for pipelins.dev.data.humancellatlas.org and
+write it to the current working diretory in letsencrypt/live/pipelines.dev.data.humancellatlas.org/

--- a/certs/get_certs.sh
+++ b/certs/get_certs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+working=$1
+domain=$2
+
+if [ $# -ne 2 ]; then
+  echo -e "Usage: bash get_certs.sh working_dir domain\n\ne.g. bash get_certs.sh $pwd pipelines.dev.data.humancellatlas.org\n"
+  exit 1
+fi
+
+docker build -t humancellatlas/secondary-analysis:0.0.1 ..
+
+docker run \
+    -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID \
+    -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY \
+    -v $working:/working \
+    humancellatlas/secondary-analysis:0.0.1 \
+    bash -c \
+    "cd /working && cp /certs/certbot-route53/certbot-route53.sh . && bash certbot-route53.sh --agree-tos --manual-public-ip-logging-ok --email mintteam@broadinstitute.org --domains $domain"


### PR DESCRIPTION
To make this easier next time we need new certificates, I created a Dockerfile and a script to build and run it, which automates the process of obtaining new certificates.

See https://elastc.com/c/SyXB5BII/405-get-new-ssl-certificates