### PR TITLE
Update integration test config for latest lira

### DIFF
--- a/test/create_lira_config.py
+++ b/test/create_lira_config.py
@@ -22,7 +22,7 @@ def run(args, env_config, secrets_config):
         {
           'subscription_id': env_config['10x_subscription_id'],
           'workflow_name': 'Adapter10xCount',
-          'analysis_wdl': '{0}/10x/count/count.wdl'.format(tenx_prefix),
+          'analysis_wdls': ['{0}/10x/count/count.wdl'.format(tenx_prefix)],
           'wdl_link': '{0}/adapter_pipelines/10x/adapter.wdl'.format(pipeline_tools_prefix),
           'wdl_default_inputs_link': '{0}/adapter_pipelines/10x/adapter_example_static.json'.format(pipeline_tools_prefix),
           'options_link': '{0}/adapter_pipelines/10x/options.json'.format(pipeline_tools_prefix)
@@ -30,10 +30,17 @@ def run(args, env_config, secrets_config):
         {
           'subscription_id': env_config['ss2_subscription_id'],
           'workflow_name': 'AdapterSs2RsemSingleSample',
-          'analysis_wdl': '{0}/smartseq2_single_sample/ss2_single_sample.wdl'.format(ss2_prefix),
-          'wdl_link': '{0}/adapter_pipelines/smart_seq2/adapter.wdl'.format(pipeline_tools_prefix),
-          'wdl_default_inputs_link': '{0}/adapter_pipelines/smart_seq2/adapter_example_static_demo.json'.format(pipeline_tools_prefix),
-          'options_link': '{0}/adapter_pipelines/smart_seq2/options.json'.format(pipeline_tools_prefix)
+          'analysis_wdls': [
+              '{0}/smartseq2_single_sample/ss2_single_sample.wdl'.format(ss2_prefix),
+              '{0}/smartseq2_single_sample/pipelines/hisat2_QC_pipeline.wdl'.format(ss2_prefix),
+              '{0}/smartseq2_single_sample/pipelines/hisat2_rsem_pipeline.wdl'.format(ss2_prefix),
+              '{0}/pipelines/tasks/hisat2.wdl'.format(ss2_prefix),
+              '{0}/pipelines/tasks/picard.wdl'.format(ss2_prefix),
+              '{0}/pipelines/tasks/rsem.wdl'.format(ss2_prefix)
+          ],
+          'wdl_link': '{0}/adapter_pipelines/ss2_hisat_rsem/adapter.wdl'.format(pipeline_tools_prefix),
+          'wdl_default_inputs_link': '{0}/adapter_pipelines/ss2_hisat_rsem/adapter_example_static.json'.format(pipeline_tools_prefix),
+          'options_link': '{0}/adapter_pipelines/ss2_hisat_rsem/options.json'.format(pipeline_tools_prefix)
         }
       ]
     }


### PR DESCRIPTION
We are modifying lira to allow for analysis wdls that have their own imports, which required changing the format of lira configs slightly: https://github.com/HumanCellAtlas/lira/pull/48/

This PR updates the integration test to use the new config format.

It also turns off the 10x part of the test, since it takes so long that we weren't bothering to run the integration test anymore. In future we can replace the 10x test with an Optimus test.

Lastly, it moves up some of the code that shuts down the docker container on error, so that errors sending in notifications will also cause the container to shut down.

See https://elastc.com/c/0v6eJH1B/465-updating-lira-to-handle-subworkflows