### PR TITLE
Updates to use latest ss2 adapter

### DIFF
--- a/test/create_lira_config.py
+++ b/test/create_lira_config.py
@@ -29,7 +29,7 @@ def run(args, env_config, secrets_config):
         },
         {
           'subscription_id': env_config['ss2_subscription_id'],
-          'workflow_name': 'AdapterSs2RsemSingleSample',
+          'workflow_name': 'AdapterSmartSeq2SingleCell',
           'analysis_wdls': [
               '{0}/smartseq2_single_sample/ss2_single_sample.wdl'.format(ss2_prefix),
               '{0}/smartseq2_single_sample/pipelines/hisat2_QC_pipeline.wdl'.format(ss2_prefix),
@@ -38,9 +38,9 @@ def run(args, env_config, secrets_config):
               '{0}/pipelines/tasks/picard.wdl'.format(ss2_prefix),
               '{0}/pipelines/tasks/rsem.wdl'.format(ss2_prefix)
           ],
-          'wdl_link': '{0}/adapter_pipelines/ss2_hisat_rsem/adapter.wdl'.format(pipeline_tools_prefix),
-          'wdl_default_inputs_link': '{0}/adapter_pipelines/ss2_hisat_rsem/adapter_example_static.json'.format(pipeline_tools_prefix),
-          'options_link': '{0}/adapter_pipelines/ss2_hisat_rsem/options.json'.format(pipeline_tools_prefix)
+          'wdl_link': '{0}/adapter_pipelines/ss2_single_sample/adapter.wdl'.format(pipeline_tools_prefix),
+          'wdl_default_inputs_link': '{0}/adapter_pipelines/ss2_single_sample/adapter_example_static.json'.format(pipeline_tools_prefix),
+          'options_link': '{0}/adapter_pipelines/ss2_single_sample/options.json'.format(pipeline_tools_prefix)
         }
       ]
     }

--- a/test/get_latest_release.py
+++ b/test/get_latest_release.py
@@ -41,11 +41,11 @@ def run(repo, tag_prefix):
             tag = Tag(int(m.group(1)), int(m.group(2)), int(m.group(3)))
             if tag > max_tag:
                 max_tag = tag
-    print(max_tag)
+    print('{0}{1}'.format(tag_prefix, max_tag))
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
-    parser.add_argument('--repo', required=True)
-    parser.add_argument('--tag_prefix')
+    parser.add_argument('--repo', required=True, help='e.g. HumanCellAtlas/lira')
+    parser.add_argument('--tag_prefix', default='v', help='e.g. smartseq2_v')
     args = parser.parse_args()
     run(args.repo, args.tag_prefix)

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -173,7 +173,7 @@ if [ $lira_mode == "image" ]; then
   else
     lira_image_version=$lira_version
   fi
-  docker pull humancellatlas/lira:$lira_image_version
+  docker pull quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version
 elif [ $lira_mode == "local" ] || [ $lira_mode == "github" ]; then
   cd $lira_dir
   if [ $lira_mode == "local" ]; then
@@ -182,7 +182,7 @@ elif [ $lira_mode == "local" ] || [ $lira_mode == "github" ]; then
     lira_image_version=$lira_version
   fi
   printf "\n\nBuilding Lira version \"$lira_image_version\" from dir: $lira_dir\n"
-  docker build -t humancellatlas/lira:$lira_image_version .
+  docker build -t quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version .
   cd $work_dir
 fi
 
@@ -190,7 +190,7 @@ fi
 if [ $tenx_mode == "github" ]; then
   if [ $tenx_version == "latest_released" ]; then
     printf "\n\nDetermining latest released version of 10x pipeline\n"
-    tenx_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix 10x_)
+    tenx_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix 10x_v)
   elif [ $tenx_version == "latest_deployed" ]; then
     printf "\n\nDetermining latest deployed version of 10x pipeline\n"
     tenx_version=$(python $script_dir/current_deployed_version.py \
@@ -212,7 +212,7 @@ fi
 if [ $ss2_mode == "github" ]; then
   if [ $ss2_version == "latest_released" ]; then
     printf "\n\nDetermining latest released version of ss2 pipeline\n"
-    ss2_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix ss2_)
+    ss2_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix smartseq2_v)
   elif [ $ss2_version == "latest_deployed" ]; then
     printf "\n\nDetermining latest deployed version of ss2 pipeline\n"
     ss2_version=$(python $script_dir/current_deployed_version.py \
@@ -268,7 +268,7 @@ docker run -d \
     $(echo "$mount_pipeline_tools" | xargs) \
     $(echo "$mount_tenx" | xargs) \
     $(echo "$mount_ss2" | xargs) \
-    humancellatlas/lira:$lira_image_version
+    quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version
 
 set +e
 function stop_lira_on_error {

--- a/test/run_int_test_locally.sh
+++ b/test/run_int_test_locally.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+repo_root=$1
+vault_token=$(cat ~/.vault-token)
+
+#env=$1
+#lira_mode=$2
+#lira_version=$3
+#infra_mode=$4
+#infra_version=$5
+#tenx_mode=$6
+#tenx_version=$7
+#ss2_mode=$8
+#ss2_version=$9
+#env_config_json=${10}
+#secrets_json=${11}
+
+script_dir=$repo_root/test
+
+bash $script_dir/render-ctmpls.sh "dev" $vault_token $repo_root
+
+bash $script_dir/integration_test.sh \
+        "dev" \
+        "image" \
+        "latest_released" \
+        "github" \
+        "ajc-create-ss2hisatrsem-adapter" \
+        "github" \
+        "latest_released" \
+        "github" \
+        "latest_released" \
+        "$script_dir/dev_config.json" \
+        "$script_dir/lira-secrets.json"


### PR DESCRIPTION
These are changes that I made while updating dev and staging Liras to run the latest Smart-seq2: https://elastc.com/c/Na3HFjea/427-release-smartseq2!

Changes to create_lira_config.py are to use latest ss2.

Also added a script to run the integration test locally (from a developer's laptop).

The rest of the changes are fixes to the ability of the integration test to find and use the latest released version of various components.