### PR TITLE
Pass in newly required parameter for gunicorn for integration test

### DIFF
--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -267,13 +267,13 @@ fi
 docker run -d \
     -p 8080:8080 \
     -e listener_config=/etc/secondary-analysis/config.json \
-    -e GOOGLE_APPLICATION_CREDENTIALS=/etc/secondary-analysis/bucket-reader-key.json \
     -v $work_dir:/etc/secondary-analysis \
     --name=lira \
     $(echo "$mount_pipeline_tools" | xargs) \
     $(echo "$mount_tenx" | xargs) \
     $(echo "$mount_ss2" | xargs) \
-    quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version
+    quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version \
+    -b '0.0.0.0:8080'
 
 set +e
 function stop_lira_on_error {

--- a/test/run_int_test_locally.sh
+++ b/test/run_int_test_locally.sh
@@ -22,7 +22,7 @@ bash $script_dir/render-ctmpls.sh "dev" $vault_token $repo_root
 bash $script_dir/integration_test.sh \
         "dev" \
         "image" \
-        "latest_released" \
+        "ds_use_gunicorn_358" \
         "github" \
         "master" \
         "github" \


### PR DESCRIPTION
Once https://github.com/HumanCellAtlas/lira/pull/49 is merged in, there is a new required parameter for gunicorn when starting the docker container.

Changing the integration test here to pass in that parameter.