### PR TITLE
Use staging Cromwell for integration test

### DIFF
--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -19,7 +19,7 @@
 # Versions can be a branch name, tag, or commit hash
 #
 # env
-# The instance of Cromwell to use. When running from a PR, this will always be dev.
+# The instance of Cromwell to use. When running from a PR, this will always be staging.
 # When running locally, the developer can choose.
 #
 # lira_mode and lira_version
@@ -258,7 +258,7 @@ docker run -i --rm \
 # 7. Start Lira
 
 # Check if an old container exists
-echo "checking for old container"
+printf "\n\nChecking for old container"
 docker stop lira || echo "container already stopped"
 docker rm -v lira || echo "container already removed"
 

--- a/test/run_int_test_from_pr.sh
+++ b/test/run_int_test_from_pr.sh
@@ -33,7 +33,7 @@ fi
 #vault_token=${12}
 
 bash $script_dir/integration_test.sh \
-        "dev" \
+        "staging" \
         "github" \
         "$lira_branch" \
         "github" \

--- a/test/run_int_test_locally.sh
+++ b/test/run_int_test_locally.sh
@@ -19,7 +19,7 @@ vault_token=$(cat ~/.vault-token)
 script_dir=$repo_root/test
 
 bash $script_dir/integration_test.sh \
-        "dev" \
+        "staging" \
         "github" \
         "master" \
         "github" \


### PR DESCRIPTION
Staging Cromwell is more stable and is a better place for these tests to run. See:
https://elastc.com/c/GkhtebrR/540-point-mintegration-test-at-staging-cromwell

This change was blocked previously because of inputs that were only accessible in dev, but I have PRs to fix that problem now:
https://github.com/HumanCellAtlas/skylab/pull/84
https://github.com/HumanCellAtlas/pipeline-tools/pull/18
