### PR TITLE
Use integration environment for PR tests

### DIFF
--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -319,7 +319,7 @@ printf "\n\nSending in notifications\n"
 ss2_workflow_id=$(docker run --rm -v $script_dir:/app \
                     -e LIRA_URL="http://lira:8080/notifications" \
                     -e NOTIFICATION_TOKEN=$notification_token \
-                    -e NOTIFICATION=/app/ss2_notification_dss_staging.json \
+                    -e NOTIFICATION=/app/ss2_notification_dss_${env}.json \
                     --link lira:lira \
                     broadinstitute/python-requests /app/send_notification.py)
 

--- a/test/run_int_test_from_pr.sh
+++ b/test/run_int_test_from_pr.sh
@@ -33,7 +33,7 @@ fi
 #vault_token=${12}
 
 bash $script_dir/integration_test.sh \
-        "staging" \
+        "test" \
         "github" \
         "$lira_branch" \
         "github" \

--- a/test/run_int_test_locally.sh
+++ b/test/run_int_test_locally.sh
@@ -19,7 +19,7 @@ vault_token=$(cat ~/.vault-token)
 script_dir=$repo_root/test
 
 bash $script_dir/integration_test.sh \
-        "staging" \
+        "test" \
         "github" \
         "master" \
         "github" \

--- a/test/ss2_notification_dss_test.json
+++ b/test/ss2_notification_dss_test.json
@@ -1,0 +1,8 @@
+{
+  "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
+  "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c",
+  "match": {
+    "bundle_uuid": "f275381f-0429-4834-b84d-52369b4b72ce",
+    "bundle_version": "2018-03-23T105249.383593Z"
+  }
+}


### PR DESCRIPTION
Switch to using the integration environment for PR tests, since it supports v5 metadata 