### PR TITLE
Fix the issue that pods are stuck on terminating status forever

### DIFF
--- a/deploy/job-manager/job-manager-deployment.yaml.ctmpl
+++ b/deploy/job-manager/job-manager-deployment.yaml.ctmpl
@@ -6,6 +6,7 @@ metadata:
     app: job-manager
 spec:
   replicas: {{ env "REPLICAS" }} # For high-availability change set to 2-4
+  revisionHistoryLimit: 1
   selector:
     matchLabels:
       app: job-manager
@@ -56,6 +57,7 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 15
           timeoutSeconds: 10
+      terminationGracePeriodSeconds: 0
       volumes:
       - name: jm-api-config
         secret:


### PR DESCRIPTION
Recently we ran into an issue that: running `kubectl apply -f deploment.yaml` fails to terminate pods from the previous replica set (pods). 

After contacting with Google support, this is a rare but known issue with Kubernetes `1.9.4-gke.1`

This PR takes Google's suggestion, setting the terminationGracePeriodSeconds to zero in the deployment yaml file, to fix the issue. It seems a long term bug fix is already included in the 1.10 cluster, we may need to wait for it until GKE fully supports 1.10 k8s.