### PR TITLE
Fix testing with Cromwell-as-a-Service

### DIFF
--- a/tests/integration_test/requirements.txt
+++ b/tests/integration_test/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.18.4
+git+git://github.com/broadinstitute/cromwell-tools.git@v0.3.1


### PR DESCRIPTION
The `await_workflow_completion.py` script was not sending requests to Cromwell-as-a-Service (CAAS) when the integration test was using Lira with CAAS. This PR updates the script to reuse the functions in `cromwell-tools` to get workflow statuses and wait for workflow completion which will work with CAAS. 

Alternatively, the `integration_test.sh` script could call the `cromwell-tools wait` command but it is currently missing the caas_key parameter. This will get fixed in https://github.com/broadinstitute/cromwell-tools/pull/31/files#diff-7a8335dce91d0dd43cc5b28bb73b4170R31