### PR TITLE
Use tagged python-requests docker image

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -388,7 +388,7 @@ ss2_workflow_id=$(docker run --rm -v $script_dir:/app \
                     -e NOTIFICATION_TOKEN=$notification_token \
                     -e NOTIFICATION=/app/ss2_notification_dss_${env}.json \
                     --link lira:lira \
-                    broadinstitute/python-requests /app/send_notification.py)
+                    broadinstitute/python-requests:3 /app/send_notification.py)
 
 printf "\nss2_workflow_id: $ss2_workflow_id"
 
@@ -406,7 +406,7 @@ if [ $use_caas == "true" ]; then
         -e TIMEOUT_MINUTES=120 \
         -e PYTHONUNBUFFERED=0 \
         --link lira:lira \
-        broadinstitute/python-requests /app/await_workflow_completion.py
+        broadinstitute/python-requests:3 /app/await_workflow_completion.py
 
 else
     export CROMWELL_USER=$(docker run -i --rm \
@@ -428,7 +428,7 @@ else
         -e TIMEOUT_MINUTES=120 \
         -e PYTHONUNBUFFERED=0 \
         --link lira:lira \
-        broadinstitute/python-requests /app/await_workflow_completion.py
+        broadinstitute/python-requests:3 /app/await_workflow_completion.py
 fi
 
 


### PR DESCRIPTION
Since there is currently a python 2.7 and python 3 version of the python-requests docker image, specify which one to use. This should also make Jenkins re-pull the image when running the mintegration test, since it is currently using the default "latest" tag.  