### PR TITLE
Update JMUI deploy script for use with Cromwell-as-a-Service

### DIFF
--- a/deploy/job-manager/capabilities_config.json
+++ b/deploy/job-manager/capabilities_config.json
@@ -37,5 +37,12 @@
     "workflow-name",
     "comment"
   ],
-  "queryExtensions": []
+  "queryExtensions": [],
+  "authentication": {
+    "isRequired": true,
+    "scopes": [
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/userinfo.email"
+    ]
+  }
 }

--- a/deploy/job-manager/capabilities_config_caas.json
+++ b/deploy/job-manager/capabilities_config_caas.json
@@ -9,6 +9,10 @@
       "display": "Submitted"
     },
     {
+      "field": "end",
+      "display": "End Time"
+    },
+    {
       "field": "labels.cromwell-workflow-id",
       "display": "Workflow ID"
     },
@@ -25,6 +29,10 @@
       "display": "Bundle UUID"
     },
     {
+      "field": "labels.caas-collection-name",
+      "display": "CaaS Collection"
+    },
+    {
       "field": "labels.comment",
       "display": "Comment"
     }
@@ -35,7 +43,16 @@
     "bundle-version",
     "workflow-version",
     "workflow-name",
-    "comment"
+    "comment",
+    "caas-collection-name"
   ],
-  "queryExtensions": []
+  "queryExtensions": [],
+  "authentication": {
+    "isRequired": true,
+    "scopes": [
+      "openid",
+      "email",
+      "profile"
+    ]
+  }
 }

--- a/deploy/job-manager/job-manager-deployment.yaml.ctmpl
+++ b/deploy/job-manager/job-manager-deployment.yaml.ctmpl
@@ -18,6 +18,7 @@ spec:
       containers:
       - name: job-manager-api
         image: {{ env "API_DOCKER_IMAGE" }}
+        imagePullPolicy: Always
         args: ["-b", ":8190", "-t", "60"]
         ports:
         - containerPort: 8190
@@ -46,6 +47,7 @@ spec:
           value: "{{ env "USE_CAAS" }}"
       - name: job-manager-ui
         image: {{ env "UI_DOCKER_IMAGE" }}
+        imagePullPolicy: Always
         ports:
         - containerPort: 80
         volumeMounts:

--- a/deploy/job-manager/job-manager-deployment.yaml.ctmpl
+++ b/deploy/job-manager/job-manager-deployment.yaml.ctmpl
@@ -22,9 +22,11 @@ spec:
         ports:
         - containerPort: 8190
         volumeMounts:
+        {{ if not (env "USE_CAAS" | parseBool) }}
         - name: jm-api-config
           mountPath: /etc/job-manager/api
           readOnly: true
+        {{ end }}
         - name: jm-api-capabilities-config
           mountPath: /etc/job-manager/capabilities/capabilities-config.json
           subPath: capabilities-config
@@ -32,12 +34,16 @@ spec:
         env:
         - name: PATH_PREFIX
           value: {{ env "API_PATH_PREFIX" }}
+        {{ if not (env "USE_CAAS" | parseBool) }}
         - name: CROMWELL_CREDENTIALS
           value: /etc/job-manager/api/config.json
+        {{ end }}
         - name: CROMWELL_URL
           value: {{ env "CROMWELL_URL" }}
         - name: CAPABILITIES_CONFIG
           value: /etc/job-manager/capabilities/capabilities-config.json
+        - name: USE_CAAS
+          value: {{ env "USE_CAAS" }}
       - name: job-manager-ui
         image: {{ env "UI_DOCKER_IMAGE" }}
         ports:
@@ -47,9 +53,11 @@ spec:
           mountPath: /etc/nginx/nginx.conf
           subPath: jm-ui-config
           readOnly: true
+      {{ if env "USE_PROXY" | parseBool }}
         - name: htpasswd
           mountPath: /etc/apache2/
           readOnly: true
+      {{ end }}
         readinessProbe:
           httpGet:
             path: /health
@@ -59,18 +67,22 @@ spec:
           timeoutSeconds: 10
       terminationGracePeriodSeconds: 0
       volumes:
+      {{ if not (env "USE_CAAS" | parseBool) }}
       - name: jm-api-config
         secret:
           secretName: {{ env "API_CONFIG"}}
           items:
           - key: config
             path: config.json
+      {{ end }}
+      {{ if env "USE_PROXY" | parseBool }}
       - name: htpasswd
         secret:
           secretName: {{ env "PROXY_CREDENTIALS_CONFIG"}}
           items:
           - key: htpasswd
             path: .htpasswd
+      {{ end }}
       - name: jm-ui-config
         configMap:
           name: {{ env "UI_CONFIG"}}

--- a/deploy/job-manager/job-manager-deployment.yaml.ctmpl
+++ b/deploy/job-manager/job-manager-deployment.yaml.ctmpl
@@ -43,7 +43,7 @@ spec:
         - name: CAPABILITIES_CONFIG
           value: /etc/job-manager/capabilities/capabilities-config.json
         - name: USE_CAAS
-          value: {{ env "USE_CAAS" }}
+          value: "{{ env "USE_CAAS" }}"
       - name: job-manager-ui
         image: {{ env "UI_DOCKER_IMAGE" }}
         ports:

--- a/deploy/job-manager/nginx.conf.ctmpl
+++ b/deploy/job-manager/nginx.conf.ctmpl
@@ -19,10 +19,10 @@ http {
         # Set up HTTP Basic Auth for Nginx here:
 
         {{ if env "USE_PROXY" | parseBool }}
-            auth_basic "Username and password required";
-            auth_basic_user_file /etc/apache2/.htpasswd;
+        auth_basic "Username and password required";
+        auth_basic_user_file /etc/apache2/.htpasswd;
         {{ else }}
-            auth_basic off;
+        auth_basic off;
         {{ end }}
 
         location / {
@@ -31,7 +31,7 @@ http {
         }
 
         location /api {
-            proxy_pass http://localhost:8190;
+            proxy_pass http://127.0.0.1:8190;
         }
 
         # This is used for health check

--- a/deploy/job-manager/nginx.conf.ctmpl
+++ b/deploy/job-manager/nginx.conf.ctmpl
@@ -17,8 +17,13 @@ http {
         root /ui/dist;
 
         # Set up HTTP Basic Auth for Nginx here:
-        auth_basic "Username and password required";
-        auth_basic_user_file /etc/apache2/.htpasswd;
+
+        {{ if env "USE_PROXY" | parseBool }}
+            auth_basic "Username and password required";
+            auth_basic_user_file /etc/apache2/.htpasswd;
+        {{ else }}
+            auth_basic off;
+        {{ end }}
 
         location / {
             try_files $uri$args $uri$args/ /index.html;
@@ -41,7 +46,7 @@ http {
 
         location /version {
             auth_basic off;
-            return 200 "{\"version\": \"{{ env "JM_VERSION" }}\"}";
+            return 200 "{\"version\": \"{{ env "JMUI_VERSION" }}\"}";
             # because default content-type is application/octet-stream,
             # browser will by default try to save the file
             # below line allows you to see it in the web page


### PR DESCRIPTION
This PR makes the following changes to the `deploy.sh` script for job-manager: 
1. Add a `USE_PROXY` parameter to optionally configure an http proxy (this will be `false` for the JMUI CaaS deployment since it will require google sign-in and users will only be able to see jobs they have permission to access through CaaS)
2. Add a `USE_CAAS` parameter. This is set as an environment variable in the deployment.yaml file and is used by the job manager. Additionally, if `USE_CAAS` is `true` the API config.json file will not get included in the deployment
3. Generalize the script to accept any `GCLOUD_PROJECT` and any` CROMWELL_URL` to use for the deployment