### PR TITLE
Add failure analysis script

### DIFF
--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -1,7 +1,19 @@
+"""
+This script queries cromwell for workflows based on the input parameters (e.g. name, statuses, start, end) and produces
+a CSV file listing the following for each:
+    - workflow id
+    - bundle id
+    - status
+    - failed task (only for failed or aborted workflows)
+    - failure message (only for failed or aborted workflows)
+
+Additionally, this script will create an additional file containing the stderr messages for each failed workflow to
+facilitate further analysis if the "record_std_err" parameter is set to true.
+"""
+
 import os
 import logging
 import argparse
-import json
 import collections
 import arrow
 import requests
@@ -276,21 +288,21 @@ def main(cromwell_url, auth, headers, output_file, record_std_err=True, start=No
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     parser = argparse.ArgumentParser()
-    parser.add_argument('--cromwell_url', default='https://cromwell.caas-dev.broadinstitute.org/api/workflows/v1')
-    parser.add_argument('--cromwell_user', required=False)
-    parser.add_argument('--cromwell_password', required=False)
-    parser.add_argument('--caas_key', required=False)
-    parser.add_argument('--bucket_reader_key', required=True)
-    parser.add_argument('--output_file', default='workflow_failures.csv')
-    parser.add_argument('--start', required=False)
-    parser.add_argument('--end', required=False)
-    parser.add_argument('--name', required=False)
-    parser.add_argument('--statuses', nargs='+', required=False)
-    parser.add_argument('--labels', nargs='+', required=False)
+    parser.add_argument('--cromwell_url', default='https://cromwell.caas-dev.broadinstitute.org/api/workflows/v1', help='Cromwell API URL')
+    parser.add_argument('--cromwell_user', required=False, help='Username for the specified Cromwell url')
+    parser.add_argument('--cromwell_password', required=False, help='Password for the specified Cromwell url')
+    parser.add_argument('--caas_key', required=False, help='Path to a service account JSON key for Cromwell-as-a-Service')
+    parser.add_argument('--bucket_reader_key', required=True, help='Path to a service account JSON key for reading from the gcloud workflow execution bucket')
+    parser.add_argument('--output_file', default='workflow_failures.csv', help='Path to the output CSV file')
+    parser.add_argument('--start', required=False, help='Start time to query by')
+    parser.add_argument('--end', required=False, help='End time to query by')
+    parser.add_argument('--name', required=False, help='Workflow name to query by')
+    parser.add_argument('--statuses', nargs='+', required=False, help='Workflow statuses to query by')
+    parser.add_argument('--labels', nargs='+', required=False, help='Workflow labels to query by, in the format key:value')
     parser.add_argument('--page_size', required=False)
     parser.add_argument('--page', required=False)
-    parser.add_argument('--expand_subworkflows', default=True)
-    parser.add_argument('--record_std_err', default=True)
+    parser.add_argument('--expand_subworkflows', default=True, help='Whether to include subworkflow metadata in the Cromwell metadata')
+    parser.add_argument('--record_std_err', default=True, help="Whether to save the stderr messages from the failed workflows to a file")
     args = parser.parse_args()
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = args.bucket_reader_key
     auth, headers = cromwell_tools._get_auth_credentials(cromwell_user=args.cromwell_user, cromwell_password=args.cromwell_password, caas_key=args.caas_key)

--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -1,0 +1,286 @@
+import os
+import logging
+import argparse
+import json
+import collections
+import arrow
+import requests
+from pipeline_tools import gcs_utils
+from cromwell_tools import cromwell_tools
+
+STATUSES = {
+    'SUCCEEDED': 'Succeeded',
+    'RUNNING': 'Running',
+    'FAILED': 'Failed',
+    'ABORTED': 'Aborted',
+    'DONE': 'Done'
+}
+
+ERRORS = {
+    'LOCK_EXCEPTION': 'Optimistic lock exception on saving entity',
+    'TIMEOUT_STATUS': 'Timed out while waiting for Valid status',
+    'BAD_GATEWAY': 'requests.exceptions.HTTPError: 502 Server Error: Bad Gateway',
+    'INCOMPLETE_READ': 'httplib.IncompleteRead'
+}
+
+
+def download_gcs_blob(gcs_client, bucket_name, source_blob_name):
+    if not gcs_client.storage_client:
+        gcs_client.storage_client
+    authenticated_gcs_client = gcs_client.storage_client
+    bucket = authenticated_gcs_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+    return blob.download_as_string()
+
+
+def get_gcs_file(gs_link):
+    bucket_name, gs_file = gcs_utils.parse_bucket_blob_from_gs_link(gs_link)
+    gcs_client = gcs_utils.GoogleCloudStorageClient(key_location=os.environ["GOOGLE_APPLICATION_CREDENTIALS"],
+                                                    scopes=['https://www.googleapis.com/auth/devstorage.read_only'])
+    result = download_gcs_blob(gcs_client, bucket_name, gs_file)
+    return result
+
+
+def query_workflows(cromwell_url, auth, headers, start=None, end=None, name=None, statuses=None, labels=None, page_size=None, page=None):
+    Query = collections.namedtuple('Query', ['start', 'end', 'name', 'statuses', 'labels', 'page_size', 'page'], verbose=False)
+    Query.__new__.__defaults__ = (None,) * len(Query._fields)
+    query = Query(start=convert_utc_to_local_time(start, 'US/Eastern') if start else None,
+                  end=convert_utc_to_local_time(end, 'US/Eastern') if end else None,
+                  name=name,
+                  statuses=statuses,
+                  labels=labels,
+                  page_size=page_size,
+                  page=page)
+    result = requests.post(url='{}/query'.format(cromwell_url), json=cromwell_query_params(query), auth=auth, headers=headers)
+    result.raise_for_status()
+    total_results = result.json()['totalResultsCount']
+    logging.info('Total results: {}'.format(str(total_results)))
+    result_list_metadata = result.json()['results']
+    return result_list_metadata
+
+
+def cromwell_query_params(query):
+    query_params = []
+    if query.start:
+        start = query.start.to('UTC').strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        query_params.append({'start': start})
+    if query.end:
+        end = query.end.to('UTC').strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+        query_params.append({'end': end})
+    if query.name:
+        query_params.append({'name': query.name})
+    if query.statuses:
+        statuses = [{'status': s} for s in set(query.statuses)]
+        query_params.extend(statuses)
+    if query.labels:
+        statuses = [{'label': l} for l in set(query.labels)]
+        query_params.extend(statuses)
+    if query.page_size:
+        query_params.append({'pageSize': str(query.page_size)})
+    if query.page:
+        query_params.append({'page': str(query.page)})
+    return query_params
+
+
+def get_metadata(cromwell_url, workflow_id, auth, headers, expand_subworkflows=True):
+    metadata_url = '{}/{}/metadata'.format(cromwell_url.strip('/'), workflow_id)
+    if expand_subworkflows:
+        metadata = requests.get(url=metadata_url, auth=auth, headers=headers, params={'expandSubWorkflows': True})
+    else:
+        metadata = requests.get(url=metadata_url, auth=auth, headers=headers)
+    metadata.raise_for_status()
+    return metadata.json()
+
+
+def parse_workflow(workflow_metadata, cromwell_url):
+    workflow_id = workflow_metadata['id']
+    bundle_id = workflow_metadata['labels']['bundle-uuid']
+
+    parsed_meta = {
+        'name': workflow_metadata['workflowName'],
+        'submission': workflow_metadata['submission'],
+        'start': workflow_metadata['start'],
+        'end': workflow_metadata.get('end'),
+        'id': workflow_id,
+        'status': workflow_metadata['status'],
+        'bundle_id': bundle_id,
+        'calls': get_tasks(workflow_metadata, workflow_id, bundle_id, cromwell_url)
+    }
+    return parsed_meta
+
+
+def get_tasks(metadata, root_workflow_id, bundle_id, cromwell_url=None):
+    tasks = []
+    calls = metadata.get('calls')
+    for task_name in calls:
+        task_metadata = calls[task_name][-1]
+        if task_metadata.get('subWorkflowMetadata'):
+            tasks.extend(get_tasks(task_metadata['subWorkflowMetadata'], root_workflow_id, bundle_id))
+        elif task_metadata.get('subWorkflowId'):
+            # If the subworkflow metadata is not embedded in the main workflow metadata, request it separately
+            logging.info('Getting metadata for {}'.format(task_metadata.get('subWorkflowId')))
+            subworkflow_metadata = get_metadata(task_metadata.get('subWorkflowId'), auth, headers, cromwell_url)
+            tasks.extend(get_tasks(subworkflow_metadata, root_workflow_id, bundle_id))
+        else:
+            tasks.append(parse_task(task_name, task_metadata, root_workflow_id, bundle_id))
+    return tasks
+
+
+def parse_task(task_name, task_metadata, root_workflow_id, bundle_id):
+    return {
+        'root_workflow_id': root_workflow_id,
+        'name': task_name,
+        'start': task_metadata['start'],
+        'end': task_metadata.get('end'),
+        'status': task_metadata['executionStatus'],
+        'failures': task_metadata.get('failures'),
+        'attempt': task_metadata['attempt'],
+        'stdout': task_metadata['stdout'],
+        'stderr': task_metadata['stderr'],
+        'bundle_id': bundle_id
+    }
+
+
+def convert_utc_to_local_time(time_string, time_zone='US/Eastern'):
+    return arrow.get(time_string).replace(tzinfo=time_zone)
+
+
+def find_duplicate_bundle_ids(bundle_ids):
+    unique_bundle_ids = set(bundle_ids)
+    logging.info('{} unique bundles out of {} total'.format(str(len(set(bundle_ids))), str(len(bundle_ids))))
+
+    # Duplicate bundles
+    bundle_count = {}
+    for _id in unique_bundle_ids:
+        bundle_count[_id] = 0
+    for _id in bundle_ids:
+        bundle_count[_id] += 1
+    duplicate_bundles = {}
+    for _id in bundle_count:
+        if bundle_count[_id] > 1:
+            duplicate_bundles[_id] = bundle_count[_id]
+    duplicate_bundles_list = duplicate_bundles.keys()
+    logging.info('{} duplicate bundles: {}'.format(str(len(duplicate_bundles_list)), list(duplicate_bundles_list)))
+    return duplicate_bundles
+
+
+def sort_workflows_by_status(workflows):
+    summary = collections.defaultdict(list)
+    for workflow in workflows:
+        status = workflow['status']
+        summary[status].append(workflow)
+    return summary
+
+
+def group_workflows_by_failed_task(workflows):
+    workflows_by_task = collections.defaultdict(list)
+    for workflow in workflows:
+        for task in workflow.get('calls'):
+            if task['status'] == STATUSES['FAILED'] or task['status'] == STATUSES['ABORTED']:
+                workflows_by_task[task['name']].append(task)
+    for task_name in workflows_by_task.keys():
+        logging.info('{}: {}'.format(task_name, len(workflows_by_task[task_name])))
+    return workflows_by_task
+
+
+def get_failure_message(task_metadata, record_std_err=True):
+    exception = task_metadata.get('failures')
+    stderr_link = task_metadata.get('stderr')
+    if stderr_link:
+        file_contents = str(get_gcs_file(stderr_link))
+        for error in ERRORS:
+            if ERRORS[error] in file_contents:
+                exception = ERRORS[error]
+    if record_std_err:
+        with open('std_err.txt', 'a') as f:
+            f.write(exception + '\n')
+    return exception
+
+
+def format_metadata_output(metadata, record_std_err):
+    status = metadata.get('status')
+    data = {
+        'bundle_id': metadata['bundle_id'],
+        'id': metadata.get('root_workflow_id') or metadata['id'],
+        'status': status,
+        'task_name': metadata.get('name', '') if status == STATUSES['FAILED'] or status == STATUSES['ABORTED'] else '',
+        'error': get_failure_message(metadata, record_std_err) if status == STATUSES['FAILED'] else ''
+    }
+    return data
+
+
+def main(cromwell_url, auth, headers, output_file, record_std_err=True, start=None, end=None, name=None, statuses=None, labels=None, page_size=None, page=None, expand_subworkflows=True):
+    # Get target workflows
+    result_list_metadata = query_workflows(cromwell_url, auth, headers, start, end, name, statuses, labels, page_size, page)
+
+    # Get workflow metadata
+    result_ids = [workflow['id'] for workflow in result_list_metadata]
+    logging.info('Retrieving Adapter Workflows\' Metadata: ')
+    adapter_metadata = []
+    for idx, workflow_id in enumerate(result_ids):
+        logging.info('Current {0}/{1}: {2}'.format(idx + 1, len(result_ids), workflow_id))
+        workflow_metadata = get_metadata(cromwell_url, workflow_id, auth, headers, expand_subworkflows=expand_subworkflows)
+        adapter_metadata.append(workflow_metadata)
+    adapter_metrics = [parse_workflow(workflow_metadata, cromwell_url) for workflow_metadata in adapter_metadata]
+
+    # Check for duplicate bundles
+    total_bundle_ids = [wf['bundle_id'] for wf in adapter_metrics]
+    find_duplicate_bundle_ids(total_bundle_ids)
+
+    # Group workflows by status
+    summary = sort_workflows_by_status(adapter_metrics)
+    for status in summary.keys():
+        workflow_count = len(summary[status])
+        message = '{}: {}'.format(status, str(workflow_count))
+        if status == STATUSES['SUCCEEDED']:
+            bundle_ids = [wf['bundle_id'] for wf in summary[status]]
+            message += ' ({} unique bundles)'.format(str(len(set(bundle_ids))))
+        logging.info(message)
+
+    workflow_data = []
+    for status in summary.keys():
+        if status != STATUSES['FAILED'] and status != STATUSES['ABORTED']:
+            workflow_data.extend([format_metadata_output(w, record_std_err) for w in summary[status]])
+
+    # Find failed tasks
+    failed_workflows = summary[STATUSES['FAILED']]
+    failed_tasks = group_workflows_by_failed_task(failed_workflows)
+    for task_name in failed_tasks:
+        workflow_data.extend([format_metadata_output(task, record_std_err) for task in failed_tasks[task_name]])
+
+    # Find last task of aborted workflows
+    aborted_workflows = summary[STATUSES['ABORTED']]
+    aborted_tasks = group_workflows_by_failed_task(aborted_workflows)
+    for task_name in aborted_tasks:
+        workflow_data.extend([format_metadata_output(task, record_std_err) for task in failed_tasks[task_name]])
+
+    with open(output_file, 'w') as f:
+        f.write('Primary Bundle ID,Workflow ID,Workflow Status,Failed Task,Workflow Error\n')
+        for each in workflow_data:
+            f.write('{},{},{},{},{}\n'.format(each['bundle_id'], each['id'], each['status'],
+                                              each['task_name'], each.get('error', '')))
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--cromwell_url', default='https://cromwell.caas-dev.broadinstitute.org/api/workflows/v1')
+    parser.add_argument('--cromwell_user', required=False)
+    parser.add_argument('--cromwell_password', required=False)
+    parser.add_argument('--caas_key', required=False)
+    parser.add_argument('--bucket_reader_key', required=False)
+    parser.add_argument('--output_file', default='workflow_failures.csv')
+    parser.add_argument('--start', required=False)
+    parser.add_argument('--end', required=False)
+    parser.add_argument('--name', required=False)
+    parser.add_argument('--statuses', nargs='+', required=False)
+    parser.add_argument('--labels', nargs='+', required=False)
+    parser.add_argument('--page_size', required=False)
+    parser.add_argument('--page', required=False)
+    parser.add_argument('--expand_subworkflows', default=True)
+    parser.add_argument('--record_std_err', default=True)
+    args = parser.parse_args()
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = args.bucket_reader_key
+    auth, headers = cromwell_tools._get_auth_credentials(cromwell_user=args.cromwell_user, cromwell_password=args.cromwell_password, caas_key=args.caas_key)
+    main(args.cromwell_url, auth, headers, args.output_file, args.record_std_err, args.start, args.end, args.name, args.statuses, args.labels,
+         args.page_size, args.page, args.expand_subworkflows)

--- a/tests/scale_test/analysis/test_data/adapter_metrics.json
+++ b/tests/scale_test/analysis/test_data/adapter_metrics.json
@@ -1,0 +1,672 @@
+[
+  {
+    "name": "AdapterSmartSeq2SingleCell",
+    "submission": "2018-05-14T16:23:19.491Z",
+    "start": "2018-05-14T16:23:19.984Z",
+    "end": "2018-05-14T17:06:25.129Z",
+    "id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+    "status": "Succeeded",
+    "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7",
+    "calls": [
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "submit.create_submission",
+        "start": "2018-05-14T16:45:40.832Z",
+        "end": "2018-05-14T16:49:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-submit/submit/06b7f2e7-025e-4f73-aa6f-561de8fc85cd/call-create_submission/create_submission-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-submit/submit/06b7f2e7-025e-4f73-aa6f-561de8fc85cd/call-create_submission/create_submission-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "submit.get_metadata",
+        "start": "2018-05-14T16:43:33.332Z",
+        "end": "2018-05-14T16:45:39.512Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-submit/submit/06b7f2e7-025e-4f73-aa6f-561de8fc85cd/call-get_metadata/get_metadata-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-submit/submit/06b7f2e7-025e-4f73-aa6f-561de8fc85cd/call-get_metadata/get_metadata-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "submit.stage_and_confirm",
+        "start": "2018-05-14T16:49:04.832Z",
+        "end": "2018-05-14T17:06:21.483Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-submit/submit/06b7f2e7-025e-4f73-aa6f-561de8fc85cd/call-stage_and_confirm/stage_and_confirm-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-submit/submit/06b7f2e7-025e-4f73-aa6f-561de8fc85cd/call-stage_and_confirm/stage_and_confirm-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "AdapterSmartSeq2SingleCell.prep",
+        "start": "2018-05-14T16:23:27.511Z",
+        "end": "2018-05-14T16:26:06.490Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-prep/prep-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-prep/prep-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "SmartSeq2SingleCell.RSEMExpression",
+        "start": "2018-05-14T16:31:41.392Z",
+        "end": "2018-05-14T16:40:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-RSEMExpression/RSEMExpression-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-RSEMExpression/RSEMExpression-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "SmartSeq2SingleCell.CollectRnaMetrics",
+        "start": "2018-05-14T16:36:10.702Z",
+        "end": "2018-05-14T16:40:39.509Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-CollectRnaMetrics/CollectRnaMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-CollectRnaMetrics/CollectRnaMetrics-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "SmartSeq2SingleCell.HISAT2PairedEnd",
+        "start": "2018-05-14T16:26:10.912Z",
+        "end": "2018-05-14T16:36:09.497Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-HISAT2PairedEnd/HISAT2PairedEnd-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-HISAT2PairedEnd/HISAT2PairedEnd-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "SmartSeq2SingleCell.HISAT2Transcriptome",
+        "start": "2018-05-14T16:26:10.912Z",
+        "end": "2018-05-14T16:31:39.498Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-HISAT2Transcriptome/HISAT2Transcriptome-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-HISAT2Transcriptome/HISAT2Transcriptome-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "SmartSeq2SingleCell.CollectDuplicationMetrics",
+        "start": "2018-05-14T16:36:10.701Z",
+        "end": "2018-05-14T16:42:18.518Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      },
+      {
+        "root_workflow_id": "6396a5f5-4ec0-4688-8faa-f2e3a4347a53",
+        "name": "SmartSeq2SingleCell.CollectMultipleMetrics",
+        "start": "2018-05-14T16:36:10.702Z",
+        "end": "2018-05-14T16:43:27.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-CollectMultipleMetrics/CollectMultipleMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/6396a5f5-4ec0-4688-8faa-f2e3a4347a53/call-analysis/SmartSeq2SingleCell/ddedcaed-ec30-4815-9105-b89bdc0a8c54/call-CollectMultipleMetrics/CollectMultipleMetrics-stderr.log",
+        "bundle_id": "aded6425-ba1a-43af-8444-d843a27d38b7"
+      }
+    ]
+  },
+  {
+    "name": "AdapterSmartSeq2SingleCell",
+    "submission": "2018-05-14T16:23:16.559Z",
+    "start": "2018-05-14T16:23:19.984Z",
+    "end": "2018-05-14T17:14:50.126Z",
+    "id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+    "status": "Succeeded",
+    "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac",
+    "calls": [
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "submit.create_submission",
+        "start": "2018-05-14T16:50:11.132Z",
+        "end": "2018-05-14T16:52:24.500Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-submit/submit/0ac21533-8992-48ed-8a3b-30d81542da67/call-create_submission/create_submission-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-submit/submit/0ac21533-8992-48ed-8a3b-30d81542da67/call-create_submission/create_submission-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "submit.get_metadata",
+        "start": "2018-05-14T16:48:00.571Z",
+        "end": "2018-05-14T16:50:09.521Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-submit/submit/0ac21533-8992-48ed-8a3b-30d81542da67/call-get_metadata/get_metadata-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-submit/submit/0ac21533-8992-48ed-8a3b-30d81542da67/call-get_metadata/get_metadata-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "submit.stage_and_confirm",
+        "start": "2018-05-14T16:52:25.771Z",
+        "end": "2018-05-14T17:14:42.483Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-submit/submit/0ac21533-8992-48ed-8a3b-30d81542da67/call-stage_and_confirm/stage_and_confirm-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-submit/submit/0ac21533-8992-48ed-8a3b-30d81542da67/call-stage_and_confirm/stage_and_confirm-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "AdapterSmartSeq2SingleCell.prep",
+        "start": "2018-05-14T16:23:27.561Z",
+        "end": "2018-05-14T16:26:06.490Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-prep/prep-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-prep/prep-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "SmartSeq2SingleCell.RSEMExpression",
+        "start": "2018-05-14T16:37:49.621Z",
+        "end": "2018-05-14T16:47:54.503Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 2,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-RSEMExpression/attempt-2/RSEMExpression-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-RSEMExpression/attempt-2/RSEMExpression-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "SmartSeq2SingleCell.CollectRnaMetrics",
+        "start": "2018-05-14T16:35:02.331Z",
+        "end": "2018-05-14T16:38:57.496Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-CollectRnaMetrics/CollectRnaMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-CollectRnaMetrics/CollectRnaMetrics-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "SmartSeq2SingleCell.HISAT2PairedEnd",
+        "start": "2018-05-14T16:26:10.912Z",
+        "end": "2018-05-14T16:35:00.499Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-HISAT2PairedEnd/HISAT2PairedEnd-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-HISAT2PairedEnd/HISAT2PairedEnd-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "SmartSeq2SingleCell.HISAT2Transcriptome",
+        "start": "2018-05-14T16:26:10.912Z",
+        "end": "2018-05-14T16:32:15.496Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-HISAT2Transcriptome/HISAT2Transcriptome-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-HISAT2Transcriptome/HISAT2Transcriptome-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "SmartSeq2SingleCell.CollectDuplicationMetrics",
+        "start": "2018-05-14T16:35:02.331Z",
+        "end": "2018-05-14T16:40:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      },
+      {
+        "root_workflow_id": "87e607fb-d3ac-4403-a32c-56f00dd89b2d",
+        "name": "SmartSeq2SingleCell.CollectMultipleMetrics",
+        "start": "2018-05-14T16:35:02.331Z",
+        "end": "2018-05-14T16:42:18.519Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-CollectMultipleMetrics/CollectMultipleMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/87e607fb-d3ac-4403-a32c-56f00dd89b2d/call-analysis/SmartSeq2SingleCell/ec8c1b64-d73a-4f3f-830e-18e3d2afd6ac/call-CollectMultipleMetrics/CollectMultipleMetrics-stderr.log",
+        "bundle_id": "5aca1624-9060-46b9-86fa-35baba2ddcac"
+      }
+    ]
+  },
+  {
+    "name": "AdapterSmartSeq2SingleCell",
+    "submission": "2018-05-14T16:24:20.275Z",
+    "start": "2018-05-14T16:24:40.158Z",
+    "end": "2018-05-14T17:53:10.126Z",
+    "id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+    "status": "Failed",
+    "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe",
+    "calls": [
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "submit.create_submission",
+        "start": "2018-05-14T16:46:50.541Z",
+        "end": "2018-05-14T16:49:00.501Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-submit/submit/af69e298-862a-44da-831a-0ea9c0d8efa4/call-create_submission/create_submission-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-submit/submit/af69e298-862a-44da-831a-0ea9c0d8efa4/call-create_submission/create_submission-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "submit.get_metadata",
+        "start": "2018-05-14T16:44:38.952Z",
+        "end": "2018-05-14T16:46:48.521Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-submit/submit/af69e298-862a-44da-831a-0ea9c0d8efa4/call-get_metadata/get_metadata-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-submit/submit/af69e298-862a-44da-831a-0ea9c0d8efa4/call-get_metadata/get_metadata-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "submit.stage_and_confirm",
+        "start": "2018-05-14T16:49:02.121Z",
+        "end": "2018-05-14T17:53:03.483Z",
+        "status": "Failed",
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job submit.stage_and_confirm:NA:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-submit/submit/af69e298-862a-44da-831a-0ea9c0d8efa4/call-stage_and_confirm/stage_and_confirm-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-submit/submit/af69e298-862a-44da-831a-0ea9c0d8efa4/call-stage_and_confirm/stage_and_confirm-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "AdapterSmartSeq2SingleCell.prep",
+        "start": "2018-05-14T16:24:47.461Z",
+        "end": "2018-05-14T16:26:39.491Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-prep/prep-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-prep/prep-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "SmartSeq2SingleCell.RSEMExpression",
+        "start": "2018-05-14T16:32:17.491Z",
+        "end": "2018-05-14T16:40:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-RSEMExpression/RSEMExpression-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-RSEMExpression/RSEMExpression-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "SmartSeq2SingleCell.CollectRnaMetrics",
+        "start": "2018-05-14T16:36:43.711Z",
+        "end": "2018-05-14T16:40:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-CollectRnaMetrics/CollectRnaMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-CollectRnaMetrics/CollectRnaMetrics-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "SmartSeq2SingleCell.HISAT2PairedEnd",
+        "start": "2018-05-14T16:26:43.931Z",
+        "end": "2018-05-14T16:36:42.492Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-HISAT2PairedEnd/HISAT2PairedEnd-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-HISAT2PairedEnd/HISAT2PairedEnd-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "SmartSeq2SingleCell.HISAT2Transcriptome",
+        "start": "2018-05-14T16:26:43.931Z",
+        "end": "2018-05-14T16:32:15.496Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-HISAT2Transcriptome/HISAT2Transcriptome-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-HISAT2Transcriptome/HISAT2Transcriptome-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "SmartSeq2SingleCell.CollectDuplicationMetrics",
+        "start": "2018-05-14T16:36:43.712Z",
+        "end": "2018-05-14T16:43:24.496Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      },
+      {
+        "root_workflow_id": "dce5943a-61eb-430f-bdb1-3510ab361aee",
+        "name": "SmartSeq2SingleCell.CollectMultipleMetrics",
+        "start": "2018-05-14T16:36:43.712Z",
+        "end": "2018-05-14T16:44:33.513Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-CollectMultipleMetrics/CollectMultipleMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/dce5943a-61eb-430f-bdb1-3510ab361aee/call-analysis/SmartSeq2SingleCell/f43a4b16-e97d-4a6a-9939-73566404f08b/call-CollectMultipleMetrics/CollectMultipleMetrics-stderr.log",
+        "bundle_id": "7c8dd0d8-b871-42ee-a41b-29e02c8faebe"
+      }
+    ]
+  },
+  {
+    "name": "AdapterSmartSeq2SingleCell",
+    "submission": "2018-05-14T16:24:22.021Z",
+    "start": "2018-05-14T16:24:40.158Z",
+    "end": "2018-05-14T16:55:15.134Z",
+    "id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+    "status": "Failed",
+    "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043",
+    "calls": [
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "submit.create_submission",
+        "start": "2018-05-14T16:48:29.481Z",
+        "end": "2018-05-14T16:51:48.510Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-submit/submit/708be02b-dd35-4837-8ea3-96e8fff4b081/call-create_submission/create_submission-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-submit/submit/708be02b-dd35-4837-8ea3-96e8fff4b081/call-create_submission/create_submission-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "submit.get_metadata",
+        "start": "2018-05-14T16:46:20.961Z",
+        "end": "2018-05-14T16:48:27.500Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-submit/submit/708be02b-dd35-4837-8ea3-96e8fff4b081/call-get_metadata/get_metadata-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-submit/submit/708be02b-dd35-4837-8ea3-96e8fff4b081/call-get_metadata/get_metadata-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "submit.stage_and_confirm",
+        "start": "2018-05-14T16:51:50.422Z",
+        "end": "2018-05-14T16:55:09.480Z",
+        "status": "Failed",
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job submit.stage_and_confirm:NA:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-submit/submit/708be02b-dd35-4837-8ea3-96e8fff4b081/call-stage_and_confirm/stage_and_confirm-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-submit/submit/708be02b-dd35-4837-8ea3-96e8fff4b081/call-stage_and_confirm/stage_and_confirm-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "AdapterSmartSeq2SingleCell.prep",
+        "start": "2018-05-14T16:24:47.521Z",
+        "end": "2018-05-14T16:26:39.491Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-prep/prep-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-prep/prep-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "SmartSeq2SingleCell.RSEMExpression",
+        "start": "2018-05-14T16:32:17.481Z",
+        "end": "2018-05-14T16:39:30.504Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-RSEMExpression/RSEMExpression-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-RSEMExpression/RSEMExpression-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "SmartSeq2SingleCell.CollectRnaMetrics",
+        "start": "2018-05-14T16:37:17.361Z",
+        "end": "2018-05-14T16:42:51.527Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-CollectRnaMetrics/CollectRnaMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-CollectRnaMetrics/CollectRnaMetrics-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "SmartSeq2SingleCell.HISAT2PairedEnd",
+        "start": "2018-05-14T16:26:43.921Z",
+        "end": "2018-05-14T16:37:15.493Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-HISAT2PairedEnd/HISAT2PairedEnd-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-HISAT2PairedEnd/HISAT2PairedEnd-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "SmartSeq2SingleCell.HISAT2Transcriptome",
+        "start": "2018-05-14T16:26:43.921Z",
+        "end": "2018-05-14T16:32:15.496Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-HISAT2Transcriptome/HISAT2Transcriptome-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-HISAT2Transcriptome/HISAT2Transcriptome-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "SmartSeq2SingleCell.CollectDuplicationMetrics",
+        "start": "2018-05-14T16:37:17.361Z",
+        "end": "2018-05-14T16:44:33.513Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      },
+      {
+        "root_workflow_id": "3d03c720-fbe1-4193-b76a-603b2a3b43df",
+        "name": "SmartSeq2SingleCell.CollectMultipleMetrics",
+        "start": "2018-05-14T16:37:17.361Z",
+        "end": "2018-05-14T16:46:15.523Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-CollectMultipleMetrics/CollectMultipleMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/3d03c720-fbe1-4193-b76a-603b2a3b43df/call-analysis/SmartSeq2SingleCell/080d14f9-49fd-485d-ae47-6486f6aee9ef/call-CollectMultipleMetrics/CollectMultipleMetrics-stderr.log",
+        "bundle_id": "506d54bf-32e6-4037-8549-3402cddfc043"
+      }
+    ]
+  },
+  {
+    "name": "AdapterSmartSeq2SingleCell",
+    "submission": "2018-05-14T16:24:30.765Z",
+    "start": "2018-05-14T16:24:40.159Z",
+    "end": "2018-05-14T17:53:05.146Z",
+    "id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+    "status": "Failed",
+    "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5",
+    "calls": [
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "submit.create_submission",
+        "start": "2018-05-14T16:46:49.801Z",
+        "end": "2018-05-14T16:49:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-submit/submit/5a084c19-0f15-4329-a3b6-9ebd3e4610ad/call-create_submission/create_submission-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-submit/submit/5a084c19-0f15-4329-a3b6-9ebd3e4610ad/call-create_submission/create_submission-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "submit.get_metadata",
+        "start": "2018-05-14T16:44:06.602Z",
+        "end": "2018-05-14T16:46:48.521Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-submit/submit/5a084c19-0f15-4329-a3b6-9ebd3e4610ad/call-get_metadata/get_metadata-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-submit/submit/5a084c19-0f15-4329-a3b6-9ebd3e4610ad/call-get_metadata/get_metadata-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "submit.stage_and_confirm",
+        "start": "2018-05-14T16:49:05.461Z",
+        "end": "2018-05-14T17:53:03.483Z",
+        "status": "Failed",
+        "failures": [
+          {
+            "causedBy": [],
+            "message": "Job submit.stage_and_confirm:NA:1 exited with return code 1 which has not been declared as a valid return code. See 'continueOnReturnCode' runtime attribute for more details."
+          }
+        ],
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-submit/submit/5a084c19-0f15-4329-a3b6-9ebd3e4610ad/call-stage_and_confirm/stage_and_confirm-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-submit/submit/5a084c19-0f15-4329-a3b6-9ebd3e4610ad/call-stage_and_confirm/stage_and_confirm-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "AdapterSmartSeq2SingleCell.prep",
+        "start": "2018-05-14T16:24:47.743Z",
+        "end": "2018-05-14T16:27:45.502Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-prep/prep-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-prep/prep-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "SmartSeq2SingleCell.RSEMExpression",
+        "start": "2018-05-14T16:32:50.321Z",
+        "end": "2018-05-14T16:40:39.509Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-RSEMExpression/RSEMExpression-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-RSEMExpression/RSEMExpression-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "SmartSeq2SingleCell.CollectRnaMetrics",
+        "start": "2018-05-14T16:36:43.902Z",
+        "end": "2018-05-14T16:40:03.505Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-CollectRnaMetrics/CollectRnaMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-CollectRnaMetrics/CollectRnaMetrics-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "SmartSeq2SingleCell.HISAT2PairedEnd",
+        "start": "2018-05-14T16:27:50.431Z",
+        "end": "2018-05-14T16:36:42.492Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-HISAT2PairedEnd/HISAT2PairedEnd-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-HISAT2PairedEnd/HISAT2PairedEnd-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "SmartSeq2SingleCell.HISAT2Transcriptome",
+        "start": "2018-05-14T16:27:50.431Z",
+        "end": "2018-05-14T16:32:48.497Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-HISAT2Transcriptome/HISAT2Transcriptome-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-HISAT2Transcriptome/HISAT2Transcriptome-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "SmartSeq2SingleCell.CollectDuplicationMetrics",
+        "start": "2018-05-14T16:36:43.902Z",
+        "end": "2018-05-14T16:42:18.519Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-CollectDuplicationMetrics/CollectDuplicationMetrics-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      },
+      {
+        "root_workflow_id": "026cc94a-2042-40de-8af8-cdfef8d23015",
+        "name": "SmartSeq2SingleCell.CollectMultipleMetrics",
+        "start": "2018-05-14T16:36:43.902Z",
+        "end": "2018-05-14T16:44:00.538Z",
+        "status": "Done",
+        "failures": null,
+        "attempt": 1,
+        "stdout": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-CollectMultipleMetrics/CollectMultipleMetrics-stdout.log",
+        "stderr": "gs://broad-dsde-mint-test-cromwell-execution/caas-cromwell-executions/AdapterSmartSeq2SingleCell/026cc94a-2042-40de-8af8-cdfef8d23015/call-analysis/SmartSeq2SingleCell/777b633d-d0b5-4031-9a23-83192b259b4c/call-CollectMultipleMetrics/CollectMultipleMetrics-stderr.log",
+        "bundle_id": "cdef34bd-30f6-402b-b21c-b4cadc3365b5"
+      }
+    ]
+  }
+]

--- a/tests/scale_test/analysis/test_failure_analysis.py
+++ b/tests/scale_test/analysis/test_failure_analysis.py
@@ -1,0 +1,62 @@
+import json
+import arrow
+import mock
+from . import failure_analysis
+
+
+def test_cromwell_query_params():
+    start = arrow.get('2018-05-14 12:00:00').replace(tzinfo='US/Eastern')
+    end = arrow.get('2018-05-14 14:30:00').replace(tzinfo='US/Eastern')
+    name = 'TestWorkflow'
+    label = 'comment:scale-test'
+    query = failure_analysis.Query.factory(
+        start=arrow.get(start).replace(tzinfo='US/Eastern'),
+        end=arrow.get(end).replace(tzinfo='US/Eastern'),
+        name=name,
+        statuses=['Failed', 'Aborted'],
+        labels=['comment:scale-test'])
+    query_params = failure_analysis.cromwell_query_params(query)
+    expected_query_params = [
+        {'start': '2018-05-14T16:00:00.000000Z'}, {'end': '2018-05-14T18:30:00.000000Z'}, {'name': name},
+        {'status': 'Failed'}, {'status': 'Aborted'}, {'label': label}
+    ]
+    for each in expected_query_params:
+        assert each in query_params
+
+
+def test_find_duplicate_bundles():
+    bundle_ids = ['bundle_1', 'bundle_1', 'bundle_2', 'bundle_2', 'bundle_2', 'bundle_3']
+    duplicate_bundles = failure_analysis.find_duplicate_bundle_ids(bundle_ids)
+    expected_duplicates = {'bundle_1': 2, 'bundle_2': 3}
+    assert duplicate_bundles == expected_duplicates
+
+
+def test_sort_workflows_by_status():
+    with open('test_data/adapter_metrics.json') as f:
+        workflows = json.load(f)
+    summary = failure_analysis.sort_workflows_by_status(workflows)
+    n_success = [workflow for workflow in workflows if workflow['status'] == 'Succeeded']
+    n_failed = [workflow for workflow in workflows if workflow['status'] == 'Failed']
+    n_aborted = [workflow for workflow in workflows if workflow['status'] == 'Aborted']
+    assert len(summary['Succeeded']) == len(n_success)
+    assert len(summary['Failed']) == len(n_failed)
+    assert len(summary['Aborted']) == len(n_aborted)
+
+
+@mock.patch('scale_test.analysis.failure_analysis.get_gcs_file')
+def test_get_failure_message(mock_get_gcs_file):
+    mock_get_gcs_file.return_value = failure_analysis.ERRORS['LOCK_EXCEPTION']
+    with open('test_data/adapter_metrics.json') as f:
+        workflows = json.load(f)
+    failed_workflow = [w for w in workflows if w['status'] == 'Failed'][0]
+    task = [t for t in failed_workflow['calls'] if t['status'] == 'Failed'][0]
+    message = failure_analysis.get_failure_message(task, record_std_err=False)
+    assert message == failure_analysis.ERRORS['LOCK_EXCEPTION']
+
+
+def test_group_workflows_by_failed_task():
+    with open('test_data/adapter_metrics.json') as f:
+        workflows = json.load(f)
+    failed_workflows = [w for w in workflows if w['status'] == 'Failed']
+    grouped_workflows = failure_analysis.group_workflows_by_failed_task(failed_workflows)
+    assert(len(grouped_workflows['submit.stage_and_confirm']) == 3)

--- a/tests/scale_test/requirements.txt
+++ b/tests/scale_test/requirements.txt
@@ -2,3 +2,7 @@ click==6.7
 tqdm==4.19.4
 pytest>=3.4.2
 requests-mock>=1.4.0
+arrow==0.12.1
+requests==2.18.4
+git+git://github.com/broadinstitute/cromwell-tools.git@v0.3.1
+git+git://github.com/broadinstitute/pipeline-tools.git@v0.19.0


### PR DESCRIPTION
This script:
- Queries Cromwell for workflows based on the input parameters and retrieves metadata for each of those workflows. Notes: 
  - If `expandSubworkflows` is false, this script will request subworkflow metadata separately
  - Does not support pagination parameters
- Logs the total number of workflows, and how many of those had unique bundle ids
- Logs number of workflows by status, and for successful workflows logs how many were unique bundles
- For each failed workflow:
  - Find the task that failed
  - Get the contents of the stderr file from gcp and check for known errors 
  - Record the stderr in a file for further analysis (With a variety of possible errors, it can be challenging to try to parse out any given error from the stderr file unless we know what to look for, so this will record all of the errors in one place to make it easier to look through) 
- For aborted workflows, find the task that the workflow was on when it was stopped
- Generate a CSV listing:
  - workflow id
  - bundle id
  - status
  - failed task (only for failed or aborted workflows)
  - failure message (only for failed or aborted workflows)

Notes: 
- The functions to get the contents of a gcs file as a string would be more appropriate in `pipeline_tools.gcs_utils.py` 