### PR TITLE
Default to query param auth for now

### DIFF
--- a/tests/integration_test/run_int_test_from_pr.sh
+++ b/tests/integration_test/run_int_test_from_pr.sh
@@ -58,4 +58,4 @@ bash $script_dir/integration_test.sh \
         "$vault_token_path" \
         "$submit_wdl_dir" \
         "true" \
-        "true"
+        "false"


### PR DESCRIPTION
PR #40 accidentally turned on hmac for the mintegration test. That won't actually work until https://github.com/HumanCellAtlas/lira/pull/78 is merged. Let's go back to query param auth until then.

See: https://elastc.com/c/VFwYoDJ$/74-add-hmac-auth-on-blue-side