### PR TITLE
Update deploy script for Job Manager for Mint.

### DIFF
--- a/deploy/job-manager/README.md
+++ b/deploy/job-manager/README.md
@@ -6,33 +6,37 @@ This folder hosts the config files and script for deploying the Job Manager on G
 - dev
 - staging
 - integration
+- caas-dev
 - prod: _No production deployments yet_
 
 ## Deployment Process
 
-To deploy the Job Manager:
+To deploy the Job Manager, please checkout this repository and:
 
-1. Make sure you have created the ingress for the job-manager in advance, refer to `job-manager-ingress.yaml.ctmpl` for the content of the ingress YAML file.
+1. Make sure your deployment environment is authenticated with Vault.
+
+2. Make sure you have created the ingress for the job-manager in advance, refer to `job-manager-ingress.yaml.ctmpl` for the content of the ingress YAML file.
 Use `kubectl apply -f job-manager-ingress.yaml` to apple the ingress.
 
-2. Make sure the following files exist in the same directory with `deploy.sh`:
+3. Make sure the following files exist in the same directory with `deploy.sh`:
     - `api-config.json.ctmpl`
-    - `capabilities_config.json`
-    - `environment.template.ts.ctmpl`
+    - `capabilities_config.json` or `capabilities_config_caas.json`
+    - `ui-config.json.ctmpl`
     - `nginx.conf.ctmpl`
     - `job-manager-deployment.yaml.ctmpl`
     - `job-manager-service.yaml`
+    - `gunicorn_args.txt`
 
-3. Make sure the following CLIs installed and configured in your current working environment correctly:
+4. Make sure the following CLIs installed and configured in your current working environment correctly:
     - `kubectl`
     - `docker`
     - `htpasswd`
 
-4. Make sure your have a valid Vault token file exists in `$HOME/.vault-token`.
+5. Make sure your have a valid Vault token file exists in `$HOME/.vault-token`.
 Otherwise you need to pass the path to the token file as the 5th argument of `deploy.sh` later.
 
-5. Run the following command with arguments:
+6. Run the following command with arguments:
 
     - `bash deploy.sh ENV(dev/staging/test) GIT_TAG USERNAME PASSWORD VAULT_TOKEN_FILE(optional)`
 
-6. Check the `/version` and `/health` endpoints of the deployed UI to validate the deployment.
+7. Check the `/version` and `/health` endpoints of the deployed UI to validate the deployment.

--- a/deploy/job-manager/deploy.sh
+++ b/deploy/job-manager/deploy.sh
@@ -32,62 +32,6 @@ function configure_kubernetes() {
     kubectl config use-context ${GKE_CONTEXT}
 }
 
-function update_submodule() {
-    local JMUI_TAG=$1
-    local TOP_LEVEL=$(git rev-parse --show-toplevel)
-
-    stdout "Updating submodule"
-    git submodule update --recursive --remote
-
-    cd "${TOP_LEVEL}/deploy/job-manager/job-manager" && git checkout ${JMUI_TAG} && cd -
-}
-
-function render_environment_ts() {
-    local CLIENT_ID=${1:-""}
-
-    stdout "Rendering environment.prod.ts for Job Manager UI"
-    docker run -i --rm \
-        -e CLIENT_ID=${CLIENT_ID} \
-        -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s \
-        /usr/local/bin/render-ctmpl.sh -k /working/environment.template.ts.ctmpl
-}
-
-function inject_angular_and_build_UI() {
-    local GCLOUD_PROJECT=$1
-    local DOCKER_TAG=$2
-    local TOP_LEVEL=$(git rev-parse --show-toplevel)
-
-    stdout "Configuring docker for gcloud"
-    yes | gcloud auth configure-docker
-
-    stdout "Injecting environment.prod.ts into submodule for Job Manager UI"
-    cp "${TOP_LEVEL}/deploy/job-manager/environment.template.ts" "${TOP_LEVEL}/deploy/job-manager/job-manager/ui/src/environments/environment.prod.ts"
-
-    stdout "Building UI docker image: gcr.io/${GCLOUD_PROJECT}/jm-cromwell-ui:${DOCKER_TAG}"
-    docker build -t gcr.io/${GCLOUD_PROJECT}/jm-cromwell-ui:${DOCKER_TAG} "${TOP_LEVEL}/deploy/job-manager/job-manager/ui" -f "${TOP_LEVEL}/deploy/job-manager/job-manager/ui/Dockerfile"
-
-    stdout "Pushing UI docker image: gcr.io/${GCLOUD_PROJECT}/jm-cromwell-ui:${DOCKER_TAG}"
-    docker push gcr.io/${GCLOUD_PROJECT}/jm-cromwell-ui:${DOCKER_TAG}
-
-    stdout "Resetting the state of submodule after injection"
-    pushd ${TOP_LEVEL}/deploy/job-manager/job-manager
-    git reset --hard HEAD
-    popd
-}
-
-function build_API() {
-    local GCLOUD_PROJECT=$1
-    local DOCKER_TAG=$2
-    local TOP_LEVEL=$(git rev-parse --show-toplevel)
-
-    # Let gcloud to build and push the API container
-    stdout "Building API docker image: gcr.io/${GCLOUD_PROJECT}/jm-cromwell-api:${DOCKER_TAG}"
-    docker build -t gcr.io/${GCLOUD_PROJECT}/jm-cromwell-api:${DOCKER_TAG} "${TOP_LEVEL}/deploy/job-manager/job-manager" -f "${TOP_LEVEL}/deploy/job-manager/job-manager/servers/cromwell/Dockerfile"
-
-    stdout "Pushing API docker image: gcr.io/${GCLOUD_PROJECT}/jm-cromwell-api:${DOCKER_TAG}"
-    docker push gcr.io/${GCLOUD_PROJECT}/jm-cromwell-api:${DOCKER_TAG}
-}
-
 function create_API_config() {
     local VAULT_ENV=$1
     local CONFIG_NAME=$2
@@ -107,23 +51,19 @@ function create_API_config() {
     kubectl create secret generic ${CONFIG_NAME} --from-file=config=./api-config.json
 }
 
-function create_API_capabilities_conf() {
-    local CONFIG_NAME=$1
-    local USE_CAAS=$2
-    local CONFIG_FILE=capabilities_config.json
+function render_UI_config() {
+    local CLIENT_ID=${1:-""}
 
-    if [ ${USE_CAAS} == "true" ]; then
-        local CONFIG_FILE=capabilities_config_caas.json
-    fi
-
-    stdout "Creating API Capabilities config configMap object: ${CONFIG_NAME}"
-    kubectl create configmap ${CONFIG_NAME} --from-file=capabilities-config=${CONFIG_FILE}
+    stdout "Rendering UI config file for Job Manager UI"
+    docker run -i --rm \
+        -e CLIENT_ID=${CLIENT_ID} \
+        -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s \
+        /usr/local/bin/render-ctmpl.sh -k /working/ui-config.json.ctmpl
 }
 
-function create_UI_conf() {
-    local CONFIG_NAME=$1
-    local JMUI_VERSION=$2
-    local USE_PROXY=$3
+function render_NGINX_conf() {
+    local JMUI_VERSION=$1
+    local USE_PROXY=$2
 
     stdout "Rendering UI's nginx.conf file"
     docker run -i --rm \
@@ -131,9 +71,28 @@ function create_UI_conf() {
         -e USE_PROXY=${USE_PROXY} \
         -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s \
         /usr/local/bin/render-ctmpl.sh -k /working/nginx.conf.ctmpl
+}
 
-    stdout "Creating UI config configMap object: ${CONFIG_NAME}"
-    kubectl create configmap ${CONFIG_NAME} --from-file=jm-ui-config=nginx.conf
+function create_jm_configmap_obj() {
+    local CONFIG_NAME=$1
+    local USE_CAAS=$2
+    local CAPABILITIES_CONFIG_FILE=capabilities_config.json
+    local UI_CONFIG_FILE=ui-config.json
+    local UI_NGINX_FILE=nginx.conf
+    local GUNICORN_CMD_ARGS=gunicorn_args.txt
+
+    if [ ${USE_CAAS} == "true" ]; then
+        local CAPABILITIES_CONFIG_FILE=capabilities_config_caas.json
+    fi
+
+    stdout "Creating Job Manager configMap object: ${CONFIG_NAME}"
+    stdout "This object contains UI config, Nginx config and capabilities config files."
+
+    kubectl create configmap ${CONFIG_NAME} \
+        --from-file=capabilities-config=${CAPABILITIES_CONFIG_FILE} \
+        --from-file=jm-nginx-config=${UI_NGINX_FILE} \
+        --from-file=jm-ui-config=${UI_CONFIG_FILE} \
+        --from-file=jm-gunicorn-args=${GUNICORN_CMD_ARGS}
 }
 
 function create_UI_proxy() {
@@ -153,12 +112,11 @@ function apply_kube_deployment() {
     local CROMWELL_URL=$1
     local API_DOCKER_IMAGE=$2
     local API_CONFIG=$3
-    local API_CAPABILITIES_CONFIG=$4
+    local JM_CONFIGMAP_OBJ=$4
     local UI_DOCKER_IMAGE=$5
     local PROXY_CREDENTIALS_CONFIG=$6
-    local UI_CONFIG=$7
-    local USE_CAAS=$8
-    local USE_PROXY=$9
+    local USE_CAAS=$7
+    local USE_PROXY=$8
     local API_PATH_PREFIX="/api/v1"
     local REPLICAS=1
 
@@ -171,8 +129,7 @@ function apply_kube_deployment() {
         -e UI_DOCKER_IMAGE=${UI_DOCKER_IMAGE} \
         -e API_CONFIG=${API_CONFIG} \
         -e PROXY_CREDENTIALS_CONFIG=${PROXY_CREDENTIALS_CONFIG} \
-        -e UI_CONFIG=${UI_CONFIG} \
-        -e API_CAPABILITIES_CONFIG=${API_CAPABILITIES_CONFIG} \
+        -e JMUI_CONFIGMAP_OBJ=${JM_CONFIGMAP_OBJ} \
         -e USE_CAAS=${USE_CAAS} \
         -e USE_PROXY=${USE_PROXY} \
         -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s \
@@ -224,7 +181,7 @@ function tear_down_rendered_files() {
     stdout "Removing all generated files"
     rm -rf ".htpasswd"
     rm -rf "api-config.json"
-    rm -rf "environment.template.ts"
+    rm -rf "ui-config.json"
     rm -rf "job-manager-deployment.yaml"
     rm -rf "job-manager-ingress.yaml"
     rm -rf "nginx.conf"
@@ -245,33 +202,18 @@ function main() {
     local VAULT_TOKEN_FILE=${11:-"$HOME/.vault-token"}
 
     local DOCKER_TAG=${JMUI_TAG}
-    local API_DOCKER_IMAGE="gcr.io/${GCLOUD_PROJECT}/jm-cromwell-api:${DOCKER_TAG}"
-    local UI_DOCKER_IMAGE="gcr.io/${GCLOUD_PROJECT}/jm-cromwell-ui:${DOCKER_TAG}"
+    local API_DOCKER_IMAGE="databiosphere/job-manager-api-cromwell:${DOCKER_TAG}"
+    local UI_DOCKER_IMAGE="databiosphere/job-manager-ui:${DOCKER_TAG}"
 
     set -e
 
     line
     configure_kubernetes ${GCLOUD_PROJECT} ${GKE_CONTEXT}
 
-    line
-    update_submodule ${JMUI_TAG}
-
-    line
-    render_environment_ts ${CLIENT_ID}
-
-    line
-    inject_angular_and_build_UI ${GCLOUD_PROJECT} ${DOCKER_TAG}
-
-    line
-    build_API ${GCLOUD_PROJECT} ${DOCKER_TAG}
-
     local API_CONFIG="cromwell-credentials-$(date '+%Y-%m-%d-%H-%M')"
-    local CAPABILITIES_CONFIG="capabilities-config-$(date '+%Y-%m-%d-%H-%M')"
+    local JM_CONFIGMAP_OBJ="jm-configmap-$(date '+%Y-%m-%d-%H-%M')"
 
     local UI_PROXY="jm-htpasswd-$(date '+%Y-%m-%d-%H-%M')"
-    local UI_CONFIG="jm-ui-config-$(date '+%Y-%m-%d-%H-%M')"
-
-    line
 
     if [ ${USE_PROXY} == "true" ]; then
         local USERNAME=${JMUI_USR}
@@ -295,19 +237,17 @@ function main() {
         fi
     fi
 
-    if create_API_capabilities_conf ${CAPABILITIES_CONFIG} ${USE_CAAS}
-    then
-        stdout "Successfully created API capabilities config."
-    else
-        tear_down_kube_configMap ${CAPABILITIES_CONFIG}
-        stderr
-    fi
+    line
+    render_UI_config ${CLIENT_ID}
 
-    if create_UI_conf ${UI_CONFIG} ${JMUI_TAG} ${USE_PROXY}
+    line
+    render_NGINX_conf ${JMUI_TAG} ${USE_PROXY}
+
+    if create_jm_configmap_obj ${JM_CONFIGMAP_OBJ} ${USE_CAAS}
     then
-        stdout "Successfully created UI config"
+        stdout "Successfully created UI configMap object."
     else
-        tear_down_kube_configMap ${UI_CONFIG}
+        tear_down_kube_configMap ${JM_CONFIGMAP_OBJ}
         stderr
     fi
 
@@ -315,7 +255,7 @@ function main() {
     apply_kube_service
 
     line
-    apply_kube_deployment ${CROMWELL_URL} ${API_DOCKER_IMAGE} ${API_CONFIG} ${CAPABILITIES_CONFIG} ${UI_DOCKER_IMAGE} ${UI_PROXY} ${UI_CONFIG} ${USE_CAAS} ${USE_PROXY}
+    apply_kube_deployment ${CROMWELL_URL} ${API_DOCKER_IMAGE} ${API_CONFIG} ${JM_CONFIGMAP_OBJ} ${UI_DOCKER_IMAGE} ${UI_PROXY} ${USE_CAAS} ${USE_PROXY}
 
 #    line
 #    Each re-deployment to the ingress will cause a ~10 minuted downtime to the Job Manager. So this script assumes that you have created your ingress before using this it. This functions is here just for completeness.

--- a/deploy/job-manager/environment.template.ts.ctmpl
+++ b/deploy/job-manager/environment.template.ts.ctmpl
@@ -1,5 +1,0 @@
-export const environment = {
-  apiUrl: '/api/v1',
-  clientId: '{{ env "CLIENT_ID" }}',
-  production: true,
-};

--- a/deploy/job-manager/gunicorn_args.txt
+++ b/deploy/job-manager/gunicorn_args.txt
@@ -1,1 +1,0 @@
-GUNICORN_CMD_ARGS="--workers=$((2 * $(getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 2) + 1)) --worker-class gevent"

--- a/deploy/job-manager/gunicorn_args.txt
+++ b/deploy/job-manager/gunicorn_args.txt
@@ -1,0 +1,1 @@
+GUNICORN_CMD_ARGS="--workers=$((2 * $(getconf _NPROCESSORS_ONLN 2>/dev/null || getconf NPROCESSORS_ONLN 2>/dev/null || echo 2) + 1)) --worker-class gevent"

--- a/deploy/job-manager/job-manager-deployment.yaml.ctmpl
+++ b/deploy/job-manager/job-manager-deployment.yaml.ctmpl
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/job-manager/api
           readOnly: true
         {{ end }}
-        - name: jm-api-capabilities-config
+        - name: jm-configmap-obj
           mountPath: /etc/job-manager/capabilities/capabilities-config.json
           subPath: capabilities-config
           readOnly: true
@@ -45,14 +45,23 @@ spec:
           value: /etc/job-manager/capabilities/capabilities-config.json
         - name: USE_CAAS
           value: "{{ env "USE_CAAS" }}"
+        - name: GUNICORN_CMD_ARGS
+          valueFrom:
+            configMapKeyRef:
+              name: {{ env "JMUI_CONFIGMAP_OBJ"}}
+              key: jm-gunicorn-args
       - name: job-manager-ui
         image: {{ env "UI_DOCKER_IMAGE" }}
         imagePullPolicy: Always
         ports:
         - containerPort: 80
         volumeMounts:
-        - name: jm-ui-config
+        - name: jm-configmap-obj
           mountPath: /etc/nginx/nginx.conf
+          subPath: jm-nginx-config
+          readOnly: true
+        - name: jm-configmap-obj
+          mountPath: /ui/dist/assets/environments/environment.json
           subPath: jm-ui-config
           readOnly: true
       {{ if env "USE_PROXY" | parseBool }}
@@ -85,9 +94,6 @@ spec:
           - key: htpasswd
             path: .htpasswd
       {{ end }}
-      - name: jm-ui-config
+      - name: jm-configmap-obj
         configMap:
-          name: {{ env "UI_CONFIG"}}
-      - name: jm-api-capabilities-config
-        configMap:
-          name: {{ env "API_CAPABILITIES_CONFIG"}}
+          name: {{ env "JMUI_CONFIGMAP_OBJ"}}

--- a/deploy/job-manager/job-manager-deployment.yaml.ctmpl
+++ b/deploy/job-manager/job-manager-deployment.yaml.ctmpl
@@ -19,7 +19,7 @@ spec:
       - name: job-manager-api
         image: {{ env "API_DOCKER_IMAGE" }}
         imagePullPolicy: Always
-        args: ["-b", ":8190", "-t", "60"]
+        args: ["-b", ":8190", "-t", "60", "-w", "{{ env "GUNICORN_WORKERS" }}", "-k", "{{ env "GUNICORN_WORKER_TYPE" }}"]
         ports:
         - containerPort: 8190
         volumeMounts:
@@ -45,11 +45,6 @@ spec:
           value: /etc/job-manager/capabilities/capabilities-config.json
         - name: USE_CAAS
           value: "{{ env "USE_CAAS" }}"
-        - name: GUNICORN_CMD_ARGS
-          valueFrom:
-            configMapKeyRef:
-              name: {{ env "JMUI_CONFIGMAP_OBJ"}}
-              key: jm-gunicorn-args
       - name: job-manager-ui
         image: {{ env "UI_DOCKER_IMAGE" }}
         imagePullPolicy: Always

--- a/deploy/job-manager/ui-config.json.ctmpl
+++ b/deploy/job-manager/ui-config.json.ctmpl
@@ -1,0 +1,5 @@
+{
+    "apiUrl": "/api/v1",
+    "clientId": "{{ env "CLIENT_ID" }}",
+    "dashboardEnabled": false
+}


### PR DESCRIPTION
This PR updates the deploy script for Job Manager, according to a recent [breaking change](https://github.com/DataBiosphere/job-manager/releases/tag/v0.2.0) to Job Manager which simplifies the deployment process:

- Remove source code checkout and typescript injection step.
- Remove submodules.
- Consolidate all of the configmap objects into one object.