### PR TITLE
Build pipeline-tools image in test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,7 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# Lira Repository
+tests/integration_test/lira/*
+tests/integration_test/mint-deployment/*

--- a/README.md
+++ b/README.md
@@ -3,9 +3,12 @@
 This repo will contain integration test scripts and other automation related to the Secondary Analysis Service, which is part of the Human Cell Atlas Data Coordination Platform.
 
 Other Secondary Analysis Service repos:
-* [lira](https://github.com/HumanCellAtlas/lira): Listens to storage service notifications and launches workflows
-* [skylab](https://github.com/HumanCellAtlas/skylab): Analysis pipelines
-* [skylab-analysis](https://github.com/HumanCellAtlas/skylab-analysis): Analysis and benchmarking reports for Skylab pipelines
-* [pipeline-tools](https://github.com/HumanCellAtlas/pipeline-tools): DCP adapter pipelines and associated tools
-* [sctools](https://github.com/HumanCellAtlas/sctools): Tools for single cell data analysis
-* [cromwell-tools](https://github.com/broadinstitute/cromwell-tools): Tools for working with the Cromwell workflow engine
+* [cromwell-tools](https://github.com/broadinstitute/cromwell-tools): Tools(Python API) for working with the Cromwell workflow engine.
+* [falcon](https://github.com/HumanCellAtlas/falcon): Throttles workflows and start queued workflows.
+* [lira](https://github.com/HumanCellAtlas/lira): Listens to storage service notifications and launches workflows.
+* [pipeline-tools](https://github.com/HumanCellAtlas/pipeline-tools): DCP adapter pipelines and associated tools.
+* [sctools](https://github.com/HumanCellAtlas/sctools): Tools for single cell data analysis.
+* [skylab](https://github.com/HumanCellAtlas/skylab): Analysis pipelines.
+* [skylab-analysis](https://github.com/HumanCellAtlas/skylab-analysis): Analysis and benchmarking reports for Skylab pipelines.
+
+

--- a/deploy/job-manager/deploy.sh
+++ b/deploy/job-manager/deploy.sh
@@ -3,7 +3,7 @@
 # This script is designed to be run by Jenkins to deploy a new Job Manager kubernetes deployment
 # =======================================
 # Example Usage:
-# bash deploy.sh broad-dsde-mint-dev gke_broad-dsde-mint-dev_us-central1-b_listener v0.0.4 \
+# bash deploy.sh broad-dsde-mint-dev gke_broad-dsde-mint-dev_us-central1-b_lira v0.0.4 \
 # "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1" false true username password dev
 # =======================================
 
@@ -28,7 +28,7 @@ function configure_kubernetes() {
     stdout "Setting to use Google project: project ${GCLOUD_PROJECT}"
     gcloud config set project ${GCLOUD_PROJECT}
 
-    stdout "Setting to use GKE cluster: project gke_${GCLOUD_PROJECT}_us-central1-b_listener"
+    stdout "Setting to use GKE cluster: project gke_${GCLOUD_PROJECT}_us-central1-b_lira"
     kubectl config use-context ${GKE_CONTEXT}
 }
 

--- a/operations/start_greenbox.sh
+++ b/operations/start_greenbox.sh
@@ -4,27 +4,33 @@
 # This script will re-create the Lira ingress and Falcon deployment to resume running analysis workflows
 
 KUBE_CONTEXT=$1
-VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
+KUBERNETES_NAMESPACE=$2
+VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"${HOME}/.vault-token"}
 
-if [ -z $KUBE_CONTEXT ]; then
+if [ -z "${KUBE_CONTEXT}" ]; then
     echo -e "\nYou must specify a Kubernetes context to use"
-    error=1
+    ERROR=1
 fi
 
-if [ $error -eq 1 ]; then
+if [ "${ERROR}" -eq 1 ]; then
     echo -e "\nUsage: bash start_greenbox.sh KUBE_CONTEXT \n"
     exit 1
 fi
 
-kubectl config use-context ${KUBE_CONTEXT}
+kubectl config use-context "${KUBE_CONTEXT}"
 
 # Get latest TLS secret
 TLS_SECRET_NAME=$(kubectl get secrets -o json | jq -c '[.items[] | select(.metadata.name | contains("tls-secret"))][-1]' | jq -r .metadata.name)
 
 echo "Re-create Lira ingress"
-docker run -i --rm -e TLS_SECRET_NAME=${TLS_SECRET_NAME} -v ${VAULT_TOKEN_FILE}:/root/.vault-token -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s /usr/local/bin/render-ctmpl.sh -k /working/lira-ingress.yaml.ctmpl
+docker run -i --rm -e TLS_SECRET_NAME="${TLS_SECRET_NAME}" \
+                   -v "${VAULT_TOKEN_FILE}":/root/.vault-token \
+                   -v "${PWD}":/working \
+                   broadinstitute/dsde-toolbox:ra_rendering \
+                   /usr/local/bin/render-ctmpl.sh \
+                   -k /working/lira-ingress.yaml.ctmpl
 
-kubectl create -f lira-ingress.yaml --record --save-config
+kubectl create -f lira-ingress.yaml --record --save-config --namespace="${KUBERNETES_NAMESPACE}"
 
 # TODO: Uncomment when Falcon is deployed
 #echo "Re-create Falcon deployment"

--- a/operations/start_greenbox.sh
+++ b/operations/start_greenbox.sh
@@ -22,9 +22,9 @@ kubectl config use-context ${KUBE_CONTEXT}
 TLS_SECRET_NAME=$(kubectl get secrets -o json | jq -c '[.items[] | select(.metadata.name | contains("tls-secret"))][-1]' | jq -r .metadata.name)
 
 echo "Re-create Lira ingress"
-docker run -i --rm -e TLS_SECRET_NAME=${TLS_SECRET_NAME} -v ${VAULT_TOKEN_FILE}:/root/.vault-token -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s /usr/local/bin/render-ctmpl.sh -k /working/listener-ingress.yaml.ctmpl
+docker run -i --rm -e TLS_SECRET_NAME=${TLS_SECRET_NAME} -v ${VAULT_TOKEN_FILE}:/root/.vault-token -v ${PWD}:/working broadinstitute/dsde-toolbox:k8s /usr/local/bin/render-ctmpl.sh -k /working/lira-ingress.yaml.ctmpl
 
-kubectl create -f listener-ingress.yaml --record --save-config
+kubectl create -f lira-ingress.yaml --record --save-config
 
 # TODO: Uncomment when Falcon is deployed
 #echo "Re-create Falcon deployment"

--- a/operations/stop_greenbox.sh
+++ b/operations/stop_greenbox.sh
@@ -36,7 +36,7 @@ kubectl config use-context $KUBE_CONTEXT
 # Delete ingress rule for Lira to stop receiving notifications
 echo "Delete Lira ingress"
 if [ $DRY_RUN == "false" ]; then
-    kubectl delete ingress listener
+    kubectl delete ingress lira
 fi
 
 # Bring down Falcon to stop releasing workflows
@@ -50,7 +50,7 @@ CAAS_KEY_FILE="caas_key.json"
 docker run -i --rm -e VAULT_TOKEN=$(cat $VAULT_TOKEN_FILE) broadinstitute/dsde-toolbox vault read \
         -format=json \
         -field=value \
-        secret/dsde/mint/$VAULT_ENV/listener/caas-${VAULT_ENV}-key.json > $CAAS_KEY_FILE
+        secret/dsde/mint/$VAULT_ENV/lira/caas-${VAULT_ENV}-key.json > $CAAS_KEY_FILE
 
 # Abort all on-hold and running workflows
 docker run --rm -v $PWD:/app \

--- a/operations/stop_greenbox.sh
+++ b/operations/stop_greenbox.sh
@@ -7,36 +7,37 @@ KUBE_CONTEXT=$1
 CROMWELL_URL=$2
 VAULT_ENV=$3
 DRY_RUN=$4
-VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"$HOME/.vault-token"}
+KUBERNETES_NAMESPACE=$5
+VAULT_TOKEN_FILE=${VAULT_TOKEN_FILE:-"${HOME}/.vault-token"}
 
-if [ -z $KUBE_CONTEXT ]; then
+if [ -z "${KUBE_CONTEXT}" ]; then
     echo -e "\nYou must specify a Kubernetes context to use"
-    error=1
-elif [ -z $CROMWELL_URL ]; then
+    ERROR=1
+elif [ -z "${CROMWELL_URL}" ]; then
     echo -e "\nYou must specify a Cromwell url"
-    error=1
-elif [ -z $VAULT_ENV ]; then
+    ERROR=1
+elif [ -z "${VAULT_ENV}" ]; then
     echo -e "\nYou must specify a vault environment for getting the CaaS service account key"
-    error=1
+    ERROR=1
 fi
 
-if [ $error -eq 1 ]; then
+if [ "${ERROR}" -eq 1 ]; then
     echo -e "\nUsage: bash stop_greenbox.sh KUBE_CONTEXT CROMWELL_URL VAULT_ENV\n"
     exit 1
 fi
 
-if [ -z $DRY_RUN ]; then
-    DRY_RUN = "false"
+if [ -z "${DRY_RUN}" ]; then
+    DRY_RUN="false"
 else
     echo "Running in dry-run mode"
 fi
 
-kubectl config use-context $KUBE_CONTEXT
+kubectl config use-context "${KUBE_CONTEXT}"
 
 # Delete ingress rule for Lira to stop receiving notifications
 echo "Delete Lira ingress"
-if [ $DRY_RUN == "false" ]; then
-    kubectl delete ingress lira
+if [ "${DRY_RUN}" == "false" ]; then
+    kubectl delete ingress lira --namespace "${KUBERNETES_NAMESPACE}"
 fi
 
 # Bring down Falcon to stop releasing workflows
@@ -47,14 +48,14 @@ fi
 # fi
 
 CAAS_KEY_FILE="caas_key.json"
-docker run -i --rm -e VAULT_TOKEN=$(cat $VAULT_TOKEN_FILE) broadinstitute/dsde-toolbox vault read \
+docker run -i --rm -e VAULT_TOKEN="$(cat ${VAULT_TOKEN_FILE})" broadinstitute/dsde-toolbox vault read \
         -format=json \
         -field=value \
-        secret/dsde/mint/$VAULT_ENV/lira/caas-${VAULT_ENV}-key.json > $CAAS_KEY_FILE
+        secret/dsde/mint/"${VAULT_ENV}"/lira/caas-"${VAULT_ENV}"-key.json > "${CAAS_KEY_FILE}"
 
 # Abort all on-hold and running workflows
 docker run --rm -v $PWD:/app \
-    -e CROMWELL_URL=$CROMWELL_URL \
-    -e CAAS_KEY=/app/$CAAS_KEY_FILE \
-    -e DRY_RUN=$DRY_RUN \
+    -e CROMWELL_URL="${CROMWELL_URL}" \
+    -e CAAS_KEY=/app/"${CAAS_KEY_FILE}" \
+    -e DRY_RUN="${DRY_RUN}" \
     quay.io/humancellatlas/secondary-analysis-mintegration /app/abort_workflows.py

--- a/tests/integration_test/current_deployed_version.py
+++ b/tests/integration_test/current_deployed_version.py
@@ -16,11 +16,13 @@ If component_name is ss2, returns "2.0.0".
 import argparse
 import csv
 
+
 def run(component_name, mint_deployment_dir, env):
     with open('{0}/{1}.tsv'.format(mint_deployment_dir, env)) as f:
         reader = csv.DictReader(f, delimiter='\t')
         row = reader.next()
         print(row[component_name])
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/tests/integration_test/get_latest_release.py
+++ b/tests/integration_test/get_latest_release.py
@@ -4,6 +4,7 @@ import argparse
 import requests
 import re
 
+
 class Tag:
     def __init__(self, major, minor, patch):
         self.v = [major, minor, patch]
@@ -22,6 +23,7 @@ class Tag:
             if s > o:
                 return True
         return False
+
 
 def run(repo, tag_prefix):
     url = 'https://api.github.com/repos/{0}/git/refs/tags/'.format(repo) 
@@ -42,6 +44,7 @@ def run(repo, tag_prefix):
             if tag > max_tag:
                 max_tag = tag
     print('{0}{1}'.format(tag_prefix, max_tag))
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -256,9 +256,14 @@ then
   LIRA_DIR="${LIRA_VERSION}"
 fi
 
-# 2. Get pipeline-tools version
+# 2. Clone pipeline-tools if needed and get version
 if [ ${PIPELINE_TOOLS_MODE} == "github" ];
 then
+  print_style "info" "Cloning pipeline-tools"
+  git clone git@github.com:HumanCellAtlas/pipeline-tools.git
+  PIPELINE_TOOLS_DIR="${PWD}/pipeline-tools"
+  cd "${PIPELINE_TOOLS_DIR}"
+
   if [ ${PIPELINE_TOOLS_VERSION} == "latest_released" ];
   then
     print_style "info" "Determining latest released version of pipeline-tools"
@@ -266,8 +271,13 @@ then
   else
     PIPELINE_TOOLS_VERSION=$(get_version pipeline-tools ${PIPELINE_TOOLS_VERSION})
   fi
+
   print_style "info" "Configuring Lira to use adapter wdls from pipeline-tools GitHub repo: ${PIPELINE_TOOLS_VERSION}"
   PIPELINE_TOOLS_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/${PIPELINE_TOOLS_VERSION}"
+
+  print_style "info" "Checking out ${PIPELINE_TOOLS_VERSION}"
+  git checkout ${PIPELINE_TOOLS_VERSION}
+
 elif [ "${PIPELINE_TOOLS_MODE}" == "local" ];
 then
   PIPELINE_TOOLS_PREFIX="/pipeline-tools"
@@ -275,11 +285,18 @@ then
   # Get absolute path to PIPELINE_TOOLS_DIR, required to mount it into docker container later
   cd "${PIPELINE_TOOLS_DIR}"
   PIPELINE_TOOLS_DIR="$(pwd)"
-  cd "${WORK_DIR}"
   print_style "info" "Configuring Lira to use adapter wdls in dir: ${PIPELINE_TOOLS_DIR}"
 fi
 
-# 3. Build or pull Lira image
+# 3. Build pipeline-tools image and push to quay
+print_style "info" "Building pipeline-tools version \"${PIPELINE_TOOLS_VERSION}\" from dir: ${PIPELINE_TOOLS_DIR}"
+PIPELINE_TOOLS_IMAGE=quay.io/humancellatlas/secondary-analysis-pipeline-tools:${PIPELINE_TOOLS_VERSION}
+docker build -t ${PIPELINE_TOOLS_IMAGE} .
+print_style "info" "Pushing pipeline-tools image to quay.io/humancellatlas/secondary-analysis-pipeline-tools"
+docker push ${PIPELINE_TOOLS_IMAGE}
+cd "${WORK_DIR}"
+
+# 4. Build or pull Lira image
 if [ ${LIRA_MODE} == "image" ];
 then
   if [ ${LIRA_VERSION} == "latest_released" ];
@@ -316,7 +333,7 @@ then
   cd "${WORK_DIR}"
 fi
 
-# 4. Get analysis pipeline versions to use
+# 5. Get analysis pipeline versions to use
 if [ ${TENX_MODE} == "github" ];
 then
   if [ ${TENX_VERSION} == "latest_released" ];
@@ -394,7 +411,7 @@ TENX_WDL_STATIC_INPUTS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/10x/adap
 TENX_WDL_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/10x/adapter.wdl"
 TENX_WORKFLOW_NAME="Adapter10xCount"
 
-# 5. Create config.json
+# 6. Create config.json
 print_style "info" "Creating Lira config"
 
 print_style "info" "LIRA_ENVIRONMENT: ${LIRA_ENVIRONMENT}"
@@ -462,7 +479,7 @@ docker run -i --rm \
               /usr/local/bin/render-ctmpls.sh \
               -k "/working/${LIRA_CONFIG_FILE}.ctmpl" || true
 
-# 6. Retrieve the caas-<<env>>-key.json file from vault
+# 7. Retrieve the caas-<<env>>-key.json file from vault
 if [ ${USE_CAAS} ];
 then
     print_style "info" "Retrieving caas service account key"
@@ -474,7 +491,7 @@ then
     mv "${CAAS_KEY_FILE}" "${LIRA_DIR}/kubernetes/"
 fi
                
-# 7. Start Lira
+# 8. Start Lira
 # Check if an old container exists
 print_style "info" "Checking for old container"
 docker stop lira || print_style "warn" "container already stopped"
@@ -555,7 +572,7 @@ function stop_lira_on_error {
 }
 trap "stop_lira_on_error" ERR
 
-# 8. Send in notifications
+# 9. Send in notifications
 
 if [ "${USE_HMAC}" == "true" ];
 then
@@ -585,7 +602,7 @@ SS2_WORKFLOW_ID=$(docker run --rm -v ${SCRIPT_DIR}:/app \
 
 print_style "info" "SS2_WORKFLOW_ID: ${SS2_WORKFLOW_ID}"
 
-# 9. Poll for completion
+# 10. Poll for completion
 print_style "info" "Awaiting workflow completion"
 
 # Uses the docker image built from Dockerfile next to this script
@@ -628,7 +645,7 @@ else
 fi
 
 
-# 10. Stop Lira
+# 11. Stop Lira
 print_style "success" "Stopping Lira"
 docker stop lira
 docker rm -v lira

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -22,16 +22,16 @@
 # The instance of Cromwell to use. When running from a PR, this will always be staging.
 # When running locally, the developer can choose.
 #
-# lira_mode and lira_version
+# LIRA_MODE and LIRA_VERSION
 # The lira_mode param can be "local", "image" or "github".
 # If "local" is specified, a local copy of the Lira code is used. In this case,
-# lira_version should be the local path to the repo.
+# LIRA_VERSION should be the local path to the repo.
 # 
 # If "image" is specified, this script will pull and run
 # a particular version of the Lira docker image specified by lira_version.
-# If lira_version == "latest_released", then the script will scan the GitHub repo
+# If LIRA_VERSION == "latest_released", then the script will scan the GitHub repo
 # for the highest tagged version and try to pull an image with the same version.
-# If lira_version == "latest_deployed", then the script will use the latest
+# If LIRA_VERSION == "latest_deployed", then the script will use the latest
 # deployed version in LIRA_ENVIRONMENT, specified in the deployment tsv. If lira_version is
 # any other value, then it is assumed to be a docker image tag version and
 # this script will attempt to pull that version.
@@ -44,14 +44,14 @@
 # out a specific branch specified by lira_version. If the branch does not exist,
 # master will be used instead.
 #
-# pipeline_tools_mode and PIPELINE_TOOLS_VERSION
+# PIPELINE_TOOLS_MODE and PIPELINE_TOOLS_VERSION
 # These parameters determine where Lira will look for adapter WDLs.
 # (pipeline-tools is also used as a Python library for Lira, but that version
 # is controlled in Lira's Dockerfile).
-# If pipeline_tools_mode == "local", then a local copy of the repo is used,
+# If PIPELINE_TOOLS_MODE == "local", then a local copy of the repo is used,
 # with the path to the repo specified in PIPELINE_TOOLS_VERSION.
 #
-# If pipeline_tools_mode == "github", then the script configures Lira to read the
+# If PIPELINE_TOOLS_MODE == "github", then the script configures Lira to read the
 # wrapper WDLS from GitHub and to use branch PIPELINE_TOOLS_VERSION. If the branch
 # does not exist, master will be used instead.
 # If PIPELINE_TOOLS_VERSION is "latest_released", then the latest tagged release
@@ -70,7 +70,7 @@
 # from GitHub. If TENX_VERSION == "latest_released" then this script will use
 # the latest tagged release in GitHub.
 #
-# SS2_MODE and ss2_version
+# SS2_MODE and SS2_VERSION
 # The SS2_MODE and SS2_VERSION params work in the same way as TENX_MODE and
 # TENX_VERSION.
 #
@@ -80,7 +80,7 @@
 # TENX_SUBSCRIPTION_ID
 # 10x subscription id
 #
-# vault_token_path
+# VAULT_TOKEN_PATH
 # Path to token file for vault auth
 #
 # SUBMIT_WDL_DIR
@@ -88,7 +88,7 @@
 # "submit_stub/" so that we don't test submission, since it is not really
 # necessary for skylab PRs.
 #
-# use_caas
+# USE_CAAS
 # Uses Cromwell-as-a-Service if true
 #
 # USE_HMAC
@@ -114,7 +114,7 @@ function print_style {
 }
 
 print_style "info" "Starting integration test"
-print_style "info" $(date +"%Y-%m-%d %H:%M:%S")
+print_style "info" "$(date +"%Y-%m-%d %H:%M:%S")"
 
 set -e
 
@@ -142,8 +142,6 @@ GCLOUD_PROJECT=${GCLOUD_PROJECT:-"broad-dsde-mint-${LIRA_ENVIRONMENT}"} # other 
 
 CAAS_ENVIRONMENT="caas-prod"
 LIRA_CONFIG_FILE="lira-config.json"
-# LIRA_DOCKER_TAG=${LIRA_DOCKER_TAG:-"ra_update_to_caas_prod"}
-# LIRA_DOCKER_IMAGE="quay.io/humancellatlas/secondary-analysis-lira:${LIRA_DOCKER_TAG}"
 
 PIPELINE_TOOLS_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/${PIPELINE_TOOLS_VERSION}"
 SERVICE=${SERVICE:-"lira"}
@@ -151,8 +149,6 @@ MAX_CROMWELL_RETRIES=${MAX_CROMWELL_RETRIES:-"1"}
 
 # Cromwell URL - usually will be caas, but can be set to local environment
 CROMWELL_URL=${CROMWELL_URL:-"https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org/api/workflows/v1"}
-
-COLLECTION_NAME=${COLLECTION_NAME:-"lira-${LIRA_ENVIRONMENT}-workflows"}
 
 # Derived Variables
 CAAS_KEY_FILE="${CAAS_ENVIRONMENT}-key.json"
@@ -174,7 +170,7 @@ fi
 
 CAAS_KEY_PATH="secret/dsde/mint/${LIRA_ENVIRONMENT}/${SERVICE}/${CAAS_ENVIRONMENT}-key.json"
 
-if [ ${LIRA_ENVIRONMENT} == "prod" ]
+if [ ${LIRA_ENVIRONMENT} == "prod" ];
 then
     DSS_URL="https://dss.data.humancellatlas.org/v1"
     SCHEMA_URL="https://schema.humancellatlas.org/"
@@ -234,22 +230,18 @@ function get_version {
 }
 
 # 1. Clone Lira if needed
-if [ "${LIRA_MODE}" == "github" ] || [ ${LIRA_MODE} == "image" ]; then
+if [ "${LIRA_MODE}" == "github" ] || [ ${LIRA_MODE} == "image" ];
+then
   print_style "info" "Cloning lira"
   git clone git@github.com:HumanCellAtlas/lira.git
 
   LIRA_DIR="${PWD}/lira"
   cd "${LIRA_DIR}"
 
-  if [ "${LIRA_VERSION}" == "latest_released" ]; then
+  if [ "${LIRA_VERSION}" == "latest_released" ];
+  then
     print_style "info" "Determining latest release tag"
     LIRA_VERSION="$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/lira)"
-  elif [ "${LIRA_VERSION}" == "latest_deployed" ]; then
-    print_style "info" "Determining latest deployed version"
-    LIRA_VERSION=$(python "${SCRIPT_DIR}/current_deployed_version.py" \
-                    --component_name lira \
-                    --env "${LIRA_ENVIRONMENT}" \
-                    --mint_deployment_dir "${MINT_DEPLOYMENT_DIR}")
   else
     LIRA_VERSION="$(get_version lira ${LIRA_VERSION})"
   fi
@@ -258,62 +250,45 @@ if [ "${LIRA_MODE}" == "github" ] || [ ${LIRA_MODE} == "image" ]; then
 
   git checkout ${LIRA_VERSION}
   cd "${WORK_DIR}"
-elif [ "${LIRA_MODE}" == "local" ]; then
+elif [ "${LIRA_MODE}" == "local" ];
+then
   print_style "info" "Using Lira in dir: ${LIRA_VERSION}"
   LIRA_DIR="${LIRA_VERSION}"
 fi
 
-# 2. Clone pipeline-tools if needed and get version
-if [ ${PIPELINE_TOOLS_MODE} == "github" ]; then
-  print_style "info" "Cloning pipeline-tools"
-  git clone git@github.com:HumanCellAtlas/pipeline-tools.git
-
-  PIPELINE_TOOLS_DIR="${PWD}/pipeline-tools"
-  cd "${PIPELINE_TOOLS_DIR}"
-
-  if [ ${PIPELINE_TOOLS_VERSION} == "latest_released" ]; then
+# 2. Get pipeline-tools version
+if [ ${PIPELINE_TOOLS_MODE} == "github" ];
+then
+  if [ ${PIPELINE_TOOLS_VERSION} == "latest_released" ];
+  then
     print_style "info" "Determining latest released version of pipeline-tools"
     PIPELINE_TOOLS_VERSION=$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/pipeline-tools)
-  elif [ ${PIPELINE_TOOLS_VERSION} == "latest_deployed" ]; then
-    print_style "info" "Determining latest deployed version of pipeline-tools"
-    PIPELINE_TOOLS_VERSION=$(python "${SCRIPT_DIR}/current_deployed_version.py" \
-                      --mint_deployment_dir "${MINT_DEPLOYMENT_DIR}" \
-                      --env "${LIRA_ENVIRONMENT}" \
-                      --component_name pipeline_tools)
   else
     PIPELINE_TOOLS_VERSION=$(get_version pipeline-tools ${PIPELINE_TOOLS_VERSION})
   fi
-
   print_style "info" "Configuring Lira to use adapter wdls from pipeline-tools GitHub repo: ${PIPELINE_TOOLS_VERSION}"
   PIPELINE_TOOLS_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/${PIPELINE_TOOLS_VERSION}"
-
-  print_style "info" "Checking out ${PIPELINE_TOOLS_VERSION}"
-  git checkout ${PIPELINE_TOOLS_VERSION}
-
-elif [ "${PIPELINE_TOOLS_MODE}" == "local" ]; then
+elif [ "${PIPELINE_TOOLS_MODE}" == "local" ];
+then
   PIPELINE_TOOLS_PREFIX="/pipeline-tools"
   PIPELINE_TOOLS_DIR="${PIPELINE_TOOLS_VERSION}"
   # Get absolute path to PIPELINE_TOOLS_DIR, required to mount it into docker container later
   cd "${PIPELINE_TOOLS_DIR}"
   PIPELINE_TOOLS_DIR="$(pwd)"
+  cd "${WORK_DIR}"
   print_style "info" "Configuring Lira to use adapter wdls in dir: ${PIPELINE_TOOLS_DIR}"
 fi
 
-# 3. Build pipeline-tools image and push to quay
-print_style "info" "Building pipeline-tools version \"${PIPELINE_TOOLS_VERSION}\" from dir: ${PIPELINE_TOOLS_DIR}"
-PIPELINE_TOOLS_IMAGE=quay.io/humancellatlas/secondary-analysis-pipeline-tools:${PIPELINE_TOOLS_VERSION}
-docker build -t ${PIPELINE_TOOLS_IMAGE} .
-print_style "info" "Pushing pipeline-tools image to quay.io/humancellatlas/secondary-analysis-pipeline-tools"
-docker push ${PIPELINE_TOOLS_IMAGE}
-cd "${WORK_DIR}"
-
 # 3. Build or pull Lira image
-if [ ${LIRA_MODE} == "image" ]; then
-  if [ ${LIRA_VERSION} == "latest_released" ]; then
+if [ ${LIRA_MODE} == "image" ];
+then
+  if [ ${LIRA_VERSION} == "latest_released" ];
+  then
     print_style "info" "Determining latest released version of Lira"
     LIRA_IMAGE_VERSION=$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/lira)
 
-  elif [ ${LIRA_VERSION} == "latest_deployed" ]; then
+  elif [ ${LIRA_VERSION} == "latest_deployed" ];
+  then
     print_style "info" "Determining latest deployed version of Lira"
     LIRA_IMAGE_VERSION=$(python ${SCRIPT_DIR}/current_deployed_version.py lira)
 
@@ -323,12 +298,15 @@ if [ ${LIRA_MODE} == "image" ]; then
 
   docker pull quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
 
-elif [ "${LIRA_MODE}" == "local" ] || [ ${LIRA_MODE} == "github" ]; then
+elif [ "${LIRA_MODE}" == "local" ] || [ ${LIRA_MODE} == "github" ];
+then
   cd "${LIRA_DIR}"
-  if [ "${LIRA_MODE}" == "local" ]; then
+  if [ "${LIRA_MODE}" == "local" ];
+  then
     LIRA_IMAGE_VERSION=local
 
-  elif [ "${LIRA_MODE}" == "github" ]; then
+  elif [ "${LIRA_MODE}" == "github" ];
+  then
     LIRA_IMAGE_VERSION=${LIRA_VERSION}
 
   fi
@@ -339,11 +317,14 @@ elif [ "${LIRA_MODE}" == "local" ] || [ ${LIRA_MODE} == "github" ]; then
 fi
 
 # 4. Get analysis pipeline versions to use
-if [ ${TENX_MODE} == "github" ]; then
-  if [ ${TENX_VERSION} == "latest_released" ]; then
+if [ ${TENX_MODE} == "github" ];
+then
+  if [ ${TENX_VERSION} == "latest_released" ];
+  then
     print_style "info" "Determining latest released version of 10x pipeline"
     TENX_VERSION="$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix 10x_v)"
-  elif [ "${TENX_VERSION}" == "latest_deployed" ]; then
+  elif [ "${TENX_VERSION}" == "latest_deployed" ];
+  then
     print_style "info" "Determining latest deployed version of 10x pipeline"
     TENX_VERSION=$(python ${SCRIPT_DIR}/current_deployed_version.py \
                       --mint_deployment_dir ${MINT_DEPLOYMENT_DIR} \
@@ -354,7 +335,8 @@ if [ ${TENX_MODE} == "github" ]; then
   fi
   TENX_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/skylab/${TENX_VERSION}"
   print_style "info" "Configuring Lira to use 10x wdl from skylab Github repo, version: ${TENX_VERSION}"
-elif [ ${TENX_MODE} == "local" ]; then
+elif [ ${TENX_MODE} == "local" ];
+then
   TENX_DIR=${TENX_VERSION}
   cd ${TENX_DIR}
   TENX_DIR=$(pwd)
@@ -363,11 +345,14 @@ elif [ ${TENX_MODE} == "local" ]; then
   print_style "info" "Using 10x wdl in dir: ${TENX_DIR}"
 fi
 
-if [ ${SS2_MODE} == "github" ]; then
-  if [ ${SS2_VERSION} == "latest_released" ]; then
+if [ ${SS2_MODE} == "github" ];
+then
+  if [ ${SS2_VERSION} == "latest_released" ];
+  then
     print_style "info" "Determining latest released version of ss2 pipeline"
     SS2_VERSION=$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix smartseq2_v)
-  elif [ ${SS2_VERSION} == "latest_deployed" ]; then
+  elif [ ${SS2_VERSION} == "latest_deployed" ];
+  then
     print_style "info" "Determining latest deployed version of ss2 pipeline"
     SS2_VERSION=$(python ${SCRIPT_DIR}/current_deployed_version.py \
                       --mint_deployment_dir ${MINT_DEPLOYMENT_DIR} \
@@ -378,7 +363,8 @@ if [ ${SS2_MODE} == "github" ]; then
   fi
   print_style "info" "Configuring Lira to use ss2 wdl from skylab GitHub repo, version: ${SS2_VERSION}"
   SS2_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/skylab/${SS2_VERSION}"
-elif [ ${SS2_MODE} == "local" ]; then
+elif [ ${SS2_MODE} == "local" ];
+then
   SS2_DIR=${SS2_VERSION}
   cd ${SS2_DIR}
   SS2_DIR=$(pwd)
@@ -477,7 +463,8 @@ docker run -i --rm \
               -k "/working/${LIRA_CONFIG_FILE}.ctmpl" || true
 
 # 6. Retrieve the caas-<<env>>-key.json file from vault
-if [ ${USE_CAAS} ]; then
+if [ ${USE_CAAS} ];
+then
     print_style "info" "Retrieving caas service account key"
     docker run -i --rm \
                    -v "${VAULT_TOKEN_PATH}":/root/.vault-token \
@@ -494,22 +481,25 @@ docker stop lira || print_style "warn" "container already stopped"
 docker rm -v lira || print_style "warn" "container already removed"
 
 print_style "info" "Starting Lira docker image\n"
-if [ ${PIPELINE_TOOLS_MODE} == "local" ]; then
+if [ ${PIPELINE_TOOLS_MODE} == "local" ];
+then
   MOUNT_PIPELINE_TOOLS="-v ${PIPELINE_TOOLS_DIR}:/pipeline-tools"
   print_style "info" "Mounting PIPELINE_TOOLS_DIR: ${PIPELINE_TOOLS_DIR}\n"
 fi
-if [ ${TENX_MODE} == "local" ]; then
+if [ ${TENX_MODE} == "local" ];
+then
   MOUNT_TENX="-v ${TENX_DIR}:/10x"
   print_style "info" "Mounting TENX_DIR: ${TENX_DIR}\n"
 fi
-if [ ${SS2_MODE} == "local" ]; then
+if [ ${SS2_MODE} == "local" ];
+then
   MOUNT_SS2="-v ${SS2_DIR}:/ss2"
   print_style "info" "Mounting SS2_DIR: ${SS2_DIR}\n"
 fi
 
 
-if [ ${USE_CAAS} ]; then
-
+if [ ${USE_CAAS} ];
+then
     print_style "info" "docker run -d \
         -p 8080:8080 \
         -e lira_config=/etc/lira/lira-config.json \
@@ -567,7 +557,8 @@ trap "stop_lira_on_error" ERR
 
 # 8. Send in notifications
 
-if [ "${USE_HMAC}" == "true" ]; then
+if [ "${USE_HMAC}" == "true" ];
+then
   print_style "info" "Getting hmac key"
   HMAC_KEY=$(docker run -i --rm \
         -e VAULT_TOKEN="$(cat ${VAULT_TOKEN_PATH})" \
@@ -598,7 +589,8 @@ print_style "info" "SS2_WORKFLOW_ID: ${SS2_WORKFLOW_ID}"
 print_style "info" "Awaiting workflow completion"
 
 # Uses the docker image built from Dockerfile next to this script
-if [ ${USE_CAAS} == "true" ]; then
+if [ ${USE_CAAS} == "true" ];
+then
     docker run --rm -v ${SCRIPT_DIR}:/app \
         -v ${LIRA_DIR}/kubernetes/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
         -e WORKFLOW_IDS=${SS2_WORKFLOW_ID} \

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -18,7 +18,7 @@
 # The following parameters are required. 
 # Versions can be a branch name, tag, or commit hash
 #
-# env
+# LIRA_ENVIRONMENT
 # The instance of Cromwell to use. When running from a PR, this will always be staging.
 # When running locally, the developer can choose.
 #
@@ -32,7 +32,7 @@
 # If lira_version == "latest_released", then the script will scan the GitHub repo
 # for the highest tagged version and try to pull an image with the same version.
 # If lira_version == "latest_deployed", then the script will use the latest
-# deployed version in env, specified in the deployment tsv. If lira_version is
+# deployed version in LIRA_ENVIRONMENT, specified in the deployment tsv. If lira_version is
 # any other value, then it is assumed to be a docker image tag version and
 # this script will attempt to pull that version.
 #
@@ -44,46 +44,46 @@
 # out a specific branch specified by lira_version. If the branch does not exist,
 # master will be used instead.
 #
-# pipeline_tools_mode and pipeline_tools_version
+# pipeline_tools_mode and PIPELINE_TOOLS_VERSION
 # These parameters determine where Lira will look for adapter WDLs.
 # (pipeline-tools is also used as a Python library for Lira, but that version
 # is controlled in Lira's Dockerfile).
 # If pipeline_tools_mode == "local", then a local copy of the repo is used,
-# with the path to the repo specified in pipeline_tools_version.
+# with the path to the repo specified in PIPELINE_TOOLS_VERSION.
 #
 # If pipeline_tools_mode == "github", then the script configures Lira to read the
-# wrapper WDLS from GitHub and to use branch pipeline_tools_version. If the branch
+# wrapper WDLS from GitHub and to use branch PIPELINE_TOOLS_VERSION. If the branch
 # does not exist, master will be used instead.
-# If pipeline_tools_version is "latest_released", then the latest tagged release
-# in GitHub will be used. If pipeline_tools_version is "latest_deployed" then
+# If PIPELINE_TOOLS_VERSION is "latest_released", then the latest tagged release
+# in GitHub will be used. If PIPELINE_TOOLS_VERSION is "latest_deployed" then
 # the latest version from the deployment tsv is used.
 #
-# tenx_mode and tenx_version
-# When tenx_mode == "local", this script will configure lira to use the 10x wdl
-# in a local directory specified by tenx_version.
+# TENX_MODE and TENX_VERSION
+# When TENX_MODE == "local", this script will configure lira to use the 10x wdl
+# in a local directory specified by TENX_VERSION.
 #
-# When tenx_mode == "github", this script will configure lira to use the 10x wdl
-# in the skylab repo, with branch specified by tenx_version. If the branch does
+# When TENX_MODE == "github", this script will configure lira to use the 10x wdl
+# in the skylab repo, with branch specified by TENX_VERSION. If the branch does
 # not exist, master will be used instead.
-# If tenx_version == "latest_deployed", then this script will find the latest
+# If TENX_VERSION == "latest_deployed", then this script will find the latest
 # wdl version in the mint deployment TSV and configure lira to read that version
-# from GitHub. If tenx_version == "latest_released" then this script will use
+# from GitHub. If TENX_VERSION == "latest_released" then this script will use
 # the latest tagged release in GitHub.
 #
-# ss2_mode and ss2_version
-# The ss2_mode and ss2_version params work in the same way as tenx_mode and
-# tenx_version.
+# SS2_MODE and ss2_version
+# The SS2_MODE and SS2_VERSION params work in the same way as TENX_MODE and
+# TENX_VERSION.
 #
-# ss2_sub_id
+# SS2_SUBSCRIPTION_ID
 # Smart-seq2 subscription id
 #
-# tenx_sub_id
+# TENX_SUBSCRIPTION_ID
 # 10x subscription id
 #
 # vault_token_path
 # Path to token file for vault auth
 #
-# submit_wdl_dir
+# SUBMIT_WDL_DIR
 # Should be an empty string except when testing skylab, in which case we use
 # "submit_stub/" so that we don't test submission, since it is not really
 # necessary for skylab PRs.
@@ -91,7 +91,7 @@
 # use_caas
 # Uses Cromwell-as-a-Service if true
 #
-# use_hmac
+# USE_HMAC
 # Uses hmac for authenticating notifications if true, otherwise uses query param token
 
 printf "\nStarting integration test\n"
@@ -99,354 +99,506 @@ date +"%Y-%m-%d %H:%M:%S"
 
 set -e
 
-ENV=$1
-lira_mode=$2
-lira_version=$3
-pipeline_tools_mode=$4
-pipeline_tools_version=$5
-tenx_mode=$6
-tenx_version=$7
-ss2_mode=$8
-ss2_version=$9
-tenx_sub_id=${10}
-ss2_sub_id=${11}
+LIRA_ENVIRONMENT=${1}
+LIRA_MODE=${2}
+LIRA_VERSION=${3}
+PIPELINE_TOOLS_MODE=${4}
+PIPELINE_TOOLS_VERSION=${5}
+TENX_MODE=${6}
+TENX_VERSION=${7}
+SS2_MODE=${8}
+SS2_VERSION=${9}
+TENX_SUBSCRIPTION_ID=${10}
+SS2_SUBSCRIPTION_ID=${11:-"placeholder_ss2_subscription_id"}
 VAULT_TOKEN_PATH=${12}
-submit_wdl_dir=${13}
-use_caas=${14}
-use_hmac=${15}
-caas_collection_name=${16:-"lira-${env}-workflows"}
+SUBMIT_WDL_DIR=${13}
+USE_CAAS=${14}
+USE_HMAC=${15}
+COLLECTION_NAME=${16:-"lira-${LIRA_ENVIRONMENT}-workflows"}
 
-work_dir=$(pwd)
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WORK_DIR=$(pwd)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-printf "\n\nenv: ${ENV}"
-printf "\nlira_mode: $lira_mode"
-printf "\nlira_version: $lira_version"
-printf "\npipeline_tools_mode: $pipeline_tools_mode"
-printf "\npipeline_tools_version: $pipeline_tools_version"
-printf "\ntenx_mode: $tenx_mode"
-printf "\ntenx_version: $tenx_version"
-printf "\nss2_mode: $ss2_mode"
-printf "\nss2_version: $ss2_version"
-printf "\ntenx_sub_id: $tenx_sub_id"
-printf "\nss2_sub_id: $ss2_sub_id"
-printf "\nvault_token_path: ${VAULT_TOKEN_PATH}"
-printf "\nsubmit_wdl_directory: $submit_wdl_dir"
-printf "\nuse_caas: $use_caas"
-printf "\nuse_hmac: $use_hmac"
-printf "\ncaas_collection_name: $caas_collection_name"
+GCLOUD_PROJECT=${GCLOUD_PROJECT:-"broad-dsde-mint-${LIRA_ENVIRONMENT}"} # other envs - broad-dsde-mint-test, broad-dsde-mint-staging, hca-dcp-pipelines-prod
 
-printf "\n\nWorking directory: $work_dir"
-printf "\nScript directory: $script_dir"
+CAAS_ENVIRONMENT="caas-prod"
+LIRA_CONFIG_FILE="lira-config.json"
+# LIRA_DOCKER_TAG=${LIRA_DOCKER_TAG:-"ra_update_to_caas_prod"}
+# LIRA_DOCKER_IMAGE="quay.io/humancellatlas/secondary-analysis-lira:${LIRA_DOCKER_TAG}"
+
+PIPELINE_TOOLS_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/${PIPELINE_TOOLS_VERSION}"
+SERVICE=${SERVICE:-"lira"}
+MAX_CROMWELL_RETRIES=${MAX_CROMWELL_RETRIES:-"1"}
+
+# Cromwell URL - usually will be caas, but can be set to local environment
+CROMWELL_URL=${CROMWELL_URL:-"https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org/api/workflows/v1"}
+
+COLLECTION_NAME=${COLLECTION_NAME:-"lira-${LIRA_ENVIRONMENT}-workflows"}
+
+# Derived Variables
+CAAS_KEY_FILE="${CAAS_ENVIRONMENT}-key.json"
+
+# Jumping through some hoops due to mismatch of names between our environments and the environments used by the other
+# teams within the HCA - this sets up the correct name for the DSS URL and the INGEST URL
+if [ ${LIRA_ENVIRONMENT} == "test" ];
+then
+    ENV="integration"
+elif [ ${LIRA_ENVIRONMENT} == "int" ];
+then
+    ENV="integration"
+elif [ ${LIRA_ENVIRONMENT} == "dev" ];
+then
+    ENV="integration"
+else
+    ENV="${LIRA_ENVIRONMENT}"
+fi
+
+CAAS_KEY_PATH="secret/dsde/mint/${LIRA_ENVIRONMENT}/${SERVICE}/${CAAS_ENVIRONMENT}-key.json"
+
+if [ ${LIRA_ENVIRONMENT} == "prod" ]
+then
+    DSS_URL="https://dss.data.humancellatlas.org/v1"
+    SCHEMA_URL="https://schema.humancellatlas.org/"
+    INGEST_URL="http://api.ingest.data.humancellatlas.org/"
+else
+    DSS_URL="https://dss.${ENV}.data.humancellatlas.org/v1"
+    SCHEMA_URL="https://schema.${ENV}.humancellatlas.org/"
+    INGEST_URL="http://api.ingest.${ENV}.data.humancellatlas.org/"
+fi
+
+GCS_ROOT="gs://${GCLOUD_PROJECT}-cromwell-execution/caas-cromwell-executions"
+
+SUBMIT_WDL="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/submit.wdl"
+
+
+
+printf "\nLIRA_ENVIRONMENT: ${LIRA_ENVIRONMENT}"
+printf "\nLIRA_MODE: ${LIRA_MODE}"
+printf "\nLIRA_VERSION: ${LIRA_VERSION}"
+printf "\nPIPELINE_TOOLS_MODE: ${PIPELINE_TOOLS_MODE}"
+printf "\nPIPELINE_TOOLS_VERSION: ${PIPELINE_TOOLS_VERSION}"
+printf "\nPIPELINE_TOOLS_PREFIX: ${PIPELINE_TOOLS_PREFIX}"
+printf "\nTENX_MODE: ${TENX_MODE}"
+printf "\nTENX_VERSION: ${TENX_VERSION}"
+printf "\nTENX_SUBSCRIPTION_ID: ${TENX_SUBSCRIPTION_ID}"
+printf "\nSS2_MODE: ${SS2_MODE}"
+printf "\nSS2_VERSION: ${SS2_VERSION}"
+printf "\nSS2_SUBSCRIPTION_ID: ${SS2_SUBSCRIPTION_ID}"
+printf "\nVAULT_TOKEN_PATH: ${VAULT_TOKEN_PATH}"
+printf "\nSUBMIT_WDL_DIR: ${SUBMIT_WDL_DIR}"
+printf "\nUSE_CAAS: ${USE_CAAS}"
+printf "\nUSE_HMAC: ${USE_HMAC}"
+printf "\nCOLLECTION_NAME: ${COLLECTION_NAME}"
+printf "\nWorking directory: ${WORK_DIR}"
+printf "\nScript directory: ${SCRIPT_DIR}"
+printf "\nCROMWELL URL: ${CROMWELL_URL}"
+printf "\nVAULT_TOKEN_PATH: ${VAULT_TOKEN_PATH}"
 
 function get_version {
-  repo=$1
-  version=$2
-  base_url="https://api.github.com/repos/HumanCellAtlas/$repo"
-  branches_url="$base_url/branches/$version"
-  commits_url="$base_url/commits/$version"
-  status_code=$(curl -s -o /dev/null -w "%{http_code}" "$branches_url")
-  if [ "$status_code" != "200" ]; then
-    status_code=$(curl -s -o /dev/null -w "%{http_code}" "$commits_url")
+  REPO=$1
+  VERSION=$2
+  BASE_URL="https://api.github.com/repos/HumanCellAtlas/${REPO}"
+  BRANCHES_URL="${BASE_URL}/branches/${VERSION}"
+  COMMITS_URL="${BASE_URL}/commits/${VERSION}"
+
+  STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${BRANCHES_URL}")
+
+  if [ "${STATUS_CODE}" != "200" ]; then
+    STATUS_CODE=$(curl -s -o /dev/null -w "%{http_code}" "${COMMITS_URL}")
   fi
-  if [ "$status_code" != "200" ]; then
+
+  if [ "${STATUS_CODE}" != "200" ]; then
     # 1>&2 prints message to stderr so it doesn't interfere with return value
-    printf "\n\nCouldn't find $repo branch or commit $version. Using master instead.\n" 1>&2
+    printf "\nCouldn't find ${REPO} branch or commit ${VERSION}. Using master instead.\n" 1>&2
     echo "master"
   else
-    echo "$version"
+    echo "${VERSION}"
   fi
 }
 
 # 1. Clone mint-deployment
-printf "\n\nCloning mint-deployment\n"
+printf "\nCloning mint-deployment\n"
 git clone git@github.com:HumanCellAtlas/mint-deployment.git
-mint_deployment_dir=mint-deployment
+MINT_DEPLOYMENT_DIR=mint-deployment
 
 # 2. Clone Lira if needed
-if [ $lira_mode == "github" ] || [ $lira_mode == "image" ]; then
-  printf "\n\nCloning lira\n"
+if [ "${LIRA_MODE}" == "github" ] || [ ${LIRA_MODE} == "image" ]; then
+  printf "\nCloning lira\n"
   git clone git@github.com:HumanCellAtlas/lira.git
-  cd lira
-  LIRA_DIR=$PWD
+
+  LIRA_DIR="${PWD}/lira"
+  cd "${LIRA_DIR}"
   printf "\nLIRA_DIR: ${LIRA_DIR}\n"
-  if [ $lira_version == "latest_released" ]; then
+
+  if [ "${LIRA_VERSION}" == "latest_released" ]; then
     printf "\nDetermining latest release tag\n"
-    lira_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/lira)
-  elif [ $lira_version == "latest_deployed" ]; then
+    LIRA_VERSION="$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/lira)"
+  elif [ "${LIRA_VERSION}" == "latest_deployed" ]; then
     printf "\nDetermining latest deployed version\n"
-    lira_version=$(python $script_dir/current_deployed_version.py \
-                    --component_name lira
-                    --env ${ENV} \
-                    --mint_deployment_dir $mint_deployment_dir)
+    LIRA_VERSION=$(python "${SCRIPT_DIR}/current_deployed_version.py" \
+                    --component_name lira \
+                    --env "${LIRA_ENVIRONMENT}" \
+                    --mint_deployment_dir "${MINT_DEPLOYMENT_DIR}")
   else
-    lira_version=$(get_version lira $lira_version)
+    LIRA_VERSION="$(get_version lira ${LIRA_VERSION})"
   fi
-  printf "\nChecking out $lira_version\n"
-  git checkout $lira_version
-  cd $work_dir
-elif [ $lira_mode == "local" ]; then
-  printf "\n\nUsing Lira in dir: $lira_version\n"
-  LIRA_DIR=$lira_version
+
+  printf "Checking out %s" "${LIRA_VERSION}"
+
+  git checkout ${LIRA_VERSION}
+  cd "${WORK_DIR}"
+elif [ "${LIRA_MODE}" == "local" ]; then
+  printf "\nUsing Lira in dir: ${LIRA_VERSION}\n"
+  LIRA_DIR="${LIRA_VERSION}"
 fi
 
 # 3. Get pipeline-tools version
-if [ $pipeline_tools_mode == "github" ]; then
-  if [ $pipeline_tools_version == "latest_released" ]; then
-    printf "\n\nDetermining latest released version of pipeline-tools\n"
-    pipeline_tools_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/pipeline-tools)
-  elif [ $pipeline_tools_version == "latest_deployed" ]; then
-    printf "\n\nDetermining latest deployed version of pipeline-tools\n"
-    pipeline_tools_version=$(python $script_dir/current_deployed_version.py \
-                      --mint_deployment_dir $mint_deployment_dir \
-                      --env ${ENV} \
+if [ ${PIPELINE_TOOLS_MODE} == "github" ]; then
+  if [ ${PIPELINE_TOOLS_VERSION} == "latest_released" ]; then
+    printf "\nDetermining latest released version of pipeline-tools\n"
+    PIPELINE_TOOLS_VERSION=$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/pipeline-tools)
+  elif [ ${PIPELINE_TOOLS_VERSION} == "latest_deployed" ]; then
+    printf "\nDetermining latest deployed version of pipeline-tools\n"
+    PIPELINE_TOOLS_VERSION=$(python "${SCRIPT_DIR}/current_deployed_version.py" \
+                      --mint_deployment_dir "${MINT_DEPLOYMENT_DIR}" \
+                      --env "${LIRA_ENVIRONMENT}" \
                       --component_name pipeline_tools)
   else
-    pipeline_tools_version=$(get_version pipeline-tools $pipeline_tools_version)
+    PIPELINE_TOOLS_VERSION=$(get_version pipeline-tools ${PIPELINE_TOOLS_VERSION})
   fi
-  printf "\nConfiguring Lira to use adapter wdls from pipeline-tools GitHub repo, version: $pipeline_tools_version\n"
-  pipeline_tools_prefix="https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/${pipeline_tools_version}"
-elif [ $pipeline_tools_mode == "local" ]; then
-  pipeline_tools_prefix="/pipeline-tools"
-  pipeline_tools_dir=$pipeline_tools_version
-  # Get absolute path to pipeline_tools_dir, required to mount it into docker container later
-  cd $pipeline_tools_dir
-  pipeline_tools_dir=$(pwd)
-  cd $work_dir
-  printf "\n\nConfiguring Lira to use adapter wdls in dir: $pipeline_tools_dir\n"
+  printf "\nConfiguring Lira to use adapter wdls from pipeline-tools GitHub repo, version: ${PIPELINE_TOOLS_VERSION}\n"
+  PIPELINE_TOOLS_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/pipeline-tools/${PIPELINE_TOOLS_VERSION}"
+elif [ "${PIPELINE_TOOLS_MODE}" == "local" ]; then
+  PIPELINE_TOOLS_PREFIX="/pipeline-tools"
+  PIPELINE_TOOLS_DIR="${PIPELINE_TOOLS_VERSION}"
+  # Get absolute path to PIPELINE_TOOLS_DIR, required to mount it into docker container later
+  cd "${PIPELINE_TOOLS_DIR}"
+  PIPELINE_TOOLS_DIR="$(pwd)"
+  cd "${WORK_DIR}"
+  printf "\nConfiguring Lira to use adapter wdls in dir: ${PIPELINE_TOOLS_DIR}\n"
 fi
 
 # 4. Build or pull Lira image
-if [ $lira_mode == "image" ]; then
-  if [ $lira_version == "latest_released" ]; then
-    printf "\n\nDetermining latest released version of Lira\n"
-    lira_image_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/lira)
-  elif [ $lira_version == "latest_deployed" ]; then
-    printf "\n\nDetermining latest deployed version of Lira\n"
-    lira_image_version=$(python $script_dir/current_deployed_version.py lira)
+if [ ${LIRA_MODE} == "image" ]; then
+  if [ ${LIRA_VERSION} == "latest_released" ]; then
+    printf "\nDetermining latest released version of Lira\n"
+    LIRA_IMAGE_VERSION=$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/lira)
+
+  elif [ ${LIRA_VERSION} == "latest_deployed" ]; then
+    printf "\nDetermining latest deployed version of Lira\n"
+    LIRA_IMAGE_VERSION=$(python ${SCRIPT_DIR}/current_deployed_version.py lira)
+
   else
-    lira_image_version=$lira_version
+    LIRA_IMAGE_VERSION=${LIRA_VERSION}
   fi
-  docker pull quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version
-elif [ $lira_mode == "local" ] || [ $lira_mode == "github" ]; then
-  cd ${LIRA_DIR}
-  if [ $lira_mode == "local" ]; then
-    lira_image_version=local
-  elif [ $lira_mode == "github" ]; then
-    lira_image_version=$lira_version
+
+  docker pull quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
+
+elif [ "${LIRA_MODE}" == "local" ] || [ ${LIRA_MODE} == "github" ]; then
+  cd "${LIRA_DIR}"
+  if [ "${LIRA_MODE}" == "local" ]; then
+    LIRA_IMAGE_VERSION=local
+
+  elif [ "${LIRA_MODE}" == "github" ]; then
+    LIRA_IMAGE_VERSION=${LIRA_VERSION}
+
   fi
-  printf "\n\nBuilding Lira version \"$lira_image_version\" from dir: ${LIRA_DIR}\n"
-  docker build -t quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version .
-  cd $work_dir
+
+  printf "\nBuilding Lira version \"${LIRA_IMAGE_VERSION}\" from dir: ${LIRA_DIR}\n"
+  docker build -t quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} .
+  cd "${WORK_DIR}"
 fi
 
 # 5. Get analysis pipeline versions to use
-if [ $tenx_mode == "github" ]; then
-  if [ $tenx_version == "latest_released" ]; then
-    printf "\n\nDetermining latest released version of 10x pipeline\n"
-    tenx_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix 10x_v)
-  elif [ $tenx_version == "latest_deployed" ]; then
-    printf "\n\nDetermining latest deployed version of 10x pipeline\n"
-    tenx_version=$(python $script_dir/current_deployed_version.py \
-                      --mint_deployment_dir $mint_deployment_dir \
-                      --env ${ENV} \
+if [ ${TENX_MODE} == "github" ]; then
+  if [ ${TENX_VERSION} == "latest_released" ]; then
+    printf "\nDetermining latest released version of 10x pipeline\n"
+    TENX_VERSION="$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix 10x_v)"
+  elif [ "${TENX_VERSION}" == "latest_deployed" ]; then
+    printf "\nDetermining latest deployed version of 10x pipeline\n"
+    TENX_VERSION=$(python ${SCRIPT_DIR}/current_deployed_version.py \
+                      --mint_deployment_dir ${MINT_DEPLOYMENT_DIR} \
+                      --env ${LIRA_ENVIRONMENT} \
                       --component_name 10x)
   else
-    tenx_version=$(get_version skylab $tenx_version)
+    TENX_VERSION=$(get_version skylab ${TENX_VERSION})
   fi
-  tenx_prefix="https://raw.githubusercontent.com/HumanCellAtlas/skylab/${tenx_version}"
-  printf "\nConfiguring Lira to use 10x wdl from skylab Github repo, version: $tenx_version\n"
-elif [ $tenx_mode == "local" ]; then
-  tenx_dir=$tenx_version
-  cd $tenx_dir
-  tenx_dir=$(pwd)
-  cd $work_dir
-  tenx_prefix="/10x"
-  printf "\n\nUsing 10x wdl in dir: $tenx_dir\n"
+  TENX_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/skylab/${TENX_VERSION}"
+  printf "\nConfiguring Lira to use 10x wdl from skylab Github repo, version: ${TENX_VERSION}\n"
+elif [ ${TENX_MODE} == "local" ]; then
+  TENX_DIR=${TENX_VERSION}
+  cd ${TENX_DIR}
+  TENX_DIR=$(pwd)
+  cd ${WORK_DIR}
+  TENX_PREFIX="/10x"
+  printf "\nUsing 10x wdl in dir: ${TENX_DIR}\n"
 fi
 
-if [ $ss2_mode == "github" ]; then
-  if [ $ss2_version == "latest_released" ]; then
-    printf "\n\nDetermining latest released version of ss2 pipeline\n"
-    ss2_version=$(python $script_dir/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix smartseq2_v)
-  elif [ $ss2_version == "latest_deployed" ]; then
-    printf "\n\nDetermining latest deployed version of ss2 pipeline\n"
-    ss2_version=$(python $script_dir/current_deployed_version.py \
-                      --mint_deployment_dir $mint_deployment_dir \
-                      --env ${ENV} \
+if [ ${SS2_MODE} == "github" ]; then
+  if [ ${SS2_VERSION} == "latest_released" ]; then
+    printf "\nDetermining latest released version of ss2 pipeline\n"
+    SS2_VERSION=$(python ${SCRIPT_DIR}/get_latest_release.py --repo HumanCellAtlas/skylab --tag_prefix smartseq2_v)
+  elif [ ${SS2_VERSION} == "latest_deployed" ]; then
+    printf "\nDetermining latest deployed version of ss2 pipeline\n"
+    SS2_VERSION=$(python ${SCRIPT_DIR}/current_deployed_version.py \
+                      --mint_deployment_dir ${MINT_DEPLOYMENT_DIR} \
+                      --env ${LIRA_ENVIRONMENT} \
                       --component_name ss2)
   else
-    ss2_version=$(get_version skylab $ss2_version)
+    SS2_VERSION=$(get_version skylab ${SS2_VERSION})
   fi
-  printf "\nConfiguring Lira to use ss2 wdl from skylab GitHub repo, version: $ss2_version\n"
-  ss2_prefix="https://raw.githubusercontent.com/HumanCellAtlas/skylab/${ss2_version}"
-elif [ $ss2_mode == "local" ]; then
-  ss2_dir=$ss2_version
-  cd $ss2_dir
-  ss2_dir=$(pwd)
-  cd $work_dir
-  ss2_prefix="/ss2"
-  printf "\n\nUsing ss2 wdl in dir: $ss2_dir\n"
+  printf "\nConfiguring Lira to use ss2 wdl from skylab GitHub repo, version: ${SS2_VERSION}\n"
+  SS2_PREFIX="https://raw.githubusercontent.com/HumanCellAtlas/skylab/${SS2_VERSION}"
+elif [ ${SS2_MODE} == "local" ]; then
+  SS2_DIR=${SS2_VERSION}
+  cd ${SS2_DIR}
+  SS2_DIR=$(pwd)
+  cd ${WORK_DIR}
+  SS2_PREFIX="/ss2"
+  printf "\nUsing ss2 wdl in dir: ${SS2_DIR}\n"
 fi
 
+
+SS2_ANALYSIS_WDLS="[
+                \"${SS2_PREFIX}/pipelines/smartseq2_single_sample/SmartSeq2SingleSample.wdl\",
+                \"${SS2_PREFIX}/library/tasks/HISAT2.wdl\",
+                \"${SS2_PREFIX}/library/tasks/Picard.wdl\",
+                \"${SS2_PREFIX}/library/tasks/RSEM.wdl\"
+            ]"
+SS2_OPTIONS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/ss2_single_sample/options.json"
+SS2_WDL_STATIC_INPUTS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/ss2_single_sample/adapter_example_static.json"
+SS2_WDL_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/ss2_single_sample/adapter.wdl"
+SS2_WORKFLOW_NAME="AdapterSmartSeq2SingleCell"
+
+# TenX Variables
+TENX_ANALYSIS_WDLS="[
+                \"${TENX_PREFIX}/pipelines/10x/count/count.wdl\"
+            ]"
+TENX_OPTIONS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/10x/options.json"
+TENX_WDL_STATIC_INPUTS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/10x/adapter_example_static.json"
+TENX_WDL_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/10x/adapter.wdl"
+TENX_WORKFLOW_NAME="Adapter10xCount"
+
 # 6. Create config.json
-printf "\n\nCreating Lira config\n\n"
+printf "\nCreating Lira config\n"
+
+echo "LIRA_ENVIRONMENT: ${LIRA_ENVIRONMENT}"
+echo "CROMWELL_URL=${CROMWELL_URL}"
+echo "USE_CAAS=${USE_CAAS}"
+echo "COLLECTION_NAME=${COLLECTION_NAME}"
+echo "GCLOUD_PROJECT=${GCLOUD_PROJECT}"
+echo "GCS_ROOT=${GCS_ROOT}"
+echo "LIRA_VERSION=${LIRA_VERSION}"
+echo "DSS_URL=${DSS_URL}"
+echo "SCHEMA_URL=${SCHEMA_URL}"
+echo "INGEST_URL=${INGEST_URL}"
+echo "USE_HMAC=${USE_HMAC}"
+echo "SUBMIT_WDL=${SUBMIT_WDL}"
+echo "MAX_CROMWELL_RETRIES=${MAX_CROMWELL_RETRIES}"
+echo "TENX_ANALYSIS_WDLS=${TENX_ANALYSIS_WDLS}"
+echo "TENX_OPTIONS_LINK=${TENX_OPTIONS_LINK}"
+echo "TENX_SUBSCRIPTION_ID=${TENX_SUBSCRIPTION_ID}"
+echo "TENX_WDL_STATIC_INPUTS_LINK=${TENX_WDL_STATIC_INPUTS_LINK}"
+echo "TENX_WDL_LINK=${TENX_WDL_LINK}"
+echo "TENX_WORKFLOW_NAME=${TENX_WORKFLOW_NAME}"
+echo "TENX_VERSION=${TENX_VERSION}"
+echo "SS2_ANALYSIS_WDLS=${SS2_ANALYSIS_WDLS}"
+echo "SS2_OPTIONS_LINK=${SS2_OPTIONS_LINK}"
+echo "SS2_SUBSCRIPTION_ID=${SS2_SUBSCRIPTION_ID}"
+echo "SS2_WDL_STATIC_INPUTS_LINK=${SS2_WDL_STATIC_INPUTS_LINK}"
+echo "SS2_WDL_LINK=${SS2_WDL_LINK}"
+echo "SS2_WORKFLOW_NAME=${SS2_WORKFLOW_NAME}"
+echo "SS2_VERSION=${SS2_VERSION}"
+echo "VAULT_TOKEN_PATH=${VAULT_TOKEN_PATH}"
+echo "PWD=${PWD}"
+echo "LIRA_IMAGE_VERSION=${LIRA_IMAGE_VERSION}"
 
 docker run -i --rm \
-    -e INPUT_PATH=/working \
-    -e OUT_PATH=/working \
-    -e ENV=${env} \
-    -e LIRA_VERSION=${lira_version} \
-    -e USE_CAAS=${use_caas} \
-    -e USE_HMAC=${use_hmac} \
-    -e COLLECTION_NAME=${caas_collection_name} \
-    -e PIPELINE_TOOLS_PREFIX=${pipeline_tools_prefix} \
-    -e SS2_VERSION=${ss2_version} \
-    -e SS2_PREFIX=${ss2_prefix} \
-    -e SS2_SUBSCRIPTION_ID=${ss2_sub_id} \
-    -e TENX_VERSION=${tenx_version} \
-    -e TENX_PREFIX=${tenx_prefix} \
-    -e TENX_SUBSCRIPTION_ID=${tenx_sub_id} \
-    -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
-    -e SUBMIT_WDL_DIR=${submit_wdl_dir} \
-    -v ${LIRA_DIR}/kubernetes:/working broadinstitute/dsde-toolbox:k8s \
-    /usr/local/bin/render-ctmpl.sh -k /working/lira-config.json.ctmpl
+              -e LIRA_ENVIRONMENT="${LIRA_ENVIRONMENT}" \
+              -e CROMWELL_URL="${CROMWELL_URL}" \
+              -e USE_CAAS="${USE_CAAS}" \
+              -e COLLECTION_NAME="${COLLECTION_NAME}" \
+              -e GCLOUD_PROJECT="${GCLOUD_PROJECT}" \
+              -e GCS_ROOT="${GCS_ROOT}" \
+              -e LIRA_VERSION="${LIRA_VERSION}" \
+              -e DSS_URL="${DSS_URL}" \
+              -e SCHEMA_URL="${SCHEMA_URL}" \
+              -e INGEST_URL="${INGEST_URL}" \
+              -e USE_HMAC="${USE_HMAC}" \
+              -e SUBMIT_WDL="${SUBMIT_WDL}" \
+              -e MAX_CROMWELL_RETRIES="${MAX_CROMWELL_RETRIES}" \
+              -e TENX_ANALYSIS_WDLS="${TENX_ANALYSIS_WDLS}" \
+              -e TENX_OPTIONS_LINK="${TENX_OPTIONS_LINK}" \
+              -e TENX_SUBSCRIPTION_ID="${TENX_SUBSCRIPTION_ID}" \
+              -e TENX_WDL_STATIC_INPUTS_LINK="${TENX_WDL_STATIC_INPUTS_LINK}" \
+              -e TENX_WDL_LINK="${TENX_WDL_LINK}" \
+              -e TENX_WORKFLOW_NAME="${TENX_WORKFLOW_NAME}" \
+              -e TENX_VERSION="${TENX_VERSION}" \
+              -e SS2_ANALYSIS_WDLS="${SS2_ANALYSIS_WDLS}" \
+              -e SS2_OPTIONS_LINK="${SS2_OPTIONS_LINK}" \
+              -e SS2_SUBSCRIPTION_ID="${SS2_SUBSCRIPTION_ID}" \
+              -e SS2_WDL_STATIC_INPUTS_LINK="${SS2_WDL_STATIC_INPUTS_LINK}" \
+              -e SS2_WDL_LINK="${SS2_WDL_LINK}" \
+              -e SS2_WORKFLOW_NAME="${SS2_WORKFLOW_NAME}" \
+              -e SS2_VERSION="${SS2_VERSION}" \
+              -v "${VAULT_TOKEN_PATH}":/root/.vault-token \
+              -v "${PWD}/lira/kubernetes":/working \
+              broadinstitute/dsde-toolbox:ra_rendering \
+              /usr/local/bin/render-ctmpls.sh \
+              -k "/working/${LIRA_CONFIG_FILE}.ctmpl" || true
 
-# 7. Start Lira
-
+# 7. Retrieve the caas-<<env>>-key.json file from vault
+if [ ${USE_CAAS} ]; then
+    printf "Retrieving caas service account key\n"
+    docker run -i --rm \
+                   -v "${VAULT_TOKEN_PATH}":/root/.vault-token \
+                   -v "${PWD}":/working broadinstitute/dsde-toolbox:ra_rendering \
+                   vault read -format=json "${CAAS_KEY_PATH}" | jq .data > "${CAAS_KEY_FILE}"
+     
+    mv "${CAAS_KEY_FILE}" "${LIRA_DIR}/kubernetes/"
+fi
+               
+# 8. Start Lira
 # Check if an old container exists
-printf "\n\nChecking for old container"
+printf "Checking for old container"
 docker stop lira || echo "container already stopped"
 docker rm -v lira || echo "container already removed"
 
-printf "\n\nStarting Lira docker image\n"
-if [ $pipeline_tools_mode == "local" ]; then
-  mount_pipeline_tools="-v $pipeline_tools_dir:/pipeline-tools"
-  printf "\nMounting pipeline_tools_dir: $pipeline_tools_dir\n"
+printf "Starting Lira docker image\n"
+if [ ${PIPELINE_TOOLS_MODE} == "local" ]; then
+  MOUNT_PIPELINE_TOOLS="-v ${PIPELINE_TOOLS_DIR}:/pipeline-tools"
+  printf "Mounting PIPELINE_TOOLS_DIR: ${PIPELINE_TOOLS_DIR}\n"
 fi
-if [ $tenx_mode == "local" ]; then
-  mount_tenx="-v $tenx_dir:/10x"
-  printf "\nMounting tenx_dir: $tenx_dir\n"
+if [ ${TENX_MODE} == "local" ]; then
+  MOUNT_TENX="-v ${TENX_DIR}:/10x"
+  printf "Mounting TENX_DIR: ${TENX_DIR}\n"
 fi
-if [ $ss2_mode == "local" ]; then
-  mount_ss2="-v $ss2_dir:/ss2"
-  printf "\nMounting ss2_dir: $ss2_dir\n"
+if [ ${SS2_MODE} == "local" ]; then
+  MOUNT_SS2="-v ${SS2_DIR}:/ss2"
+  printf "Mounting SS2_DIR: ${SS2_DIR}\n"
 fi
 
 
-if [ $use_caas ]; then
-    echo "Getting private key for caas"
-    docker run -i --rm \
-        -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
-        broadinstitute/dsde-toolbox vault read \
-        -format=json \
-        -field=data \
-        secret/dsde/mint/${ENV}/lira/caas-prod-key.json > ${LIRA_DIR}/kubernetes/caas_key.json
+if [ ${USE_CAAS} ]; then
+
+    echo "docker run -d \
+        -p 8080:8080 \
+        -e lira_config=/etc/lira/lira-config.json \
+        -e caas_key=/etc/lira/kubernetes/${CAAS_ENVIRONMENT}-key.json \
+        -v ${LIRA_DIR}/kubernetes/lira-config.json:/etc/lira/lira-config.json \
+        -v ${LIRA_DIR}/kubernetes/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+        --name=lira \
+        $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
+        $(echo ${MOUNT_TENX} | xargs) \
+        $(echo ${MOUNT_SS2} | xargs) \
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}"
 
     docker run -d \
         -p 8080:8080 \
         -e lira_config=/etc/lira/lira-config.json \
-        -e caas_key=/etc/lira/caas_key.json \
-        -v ${LIRA_DIR}/kubernetes/lira-config.json:/etc/lira/lira-config.json \
-        -v ${LIRA_DIR}/kubernetes/caas_key.json:/etc/lira/caas_key.json \
+        -e caas_key=/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+        -v "${LIRA_DIR}/kubernetes/lira-config.json":/etc/lira/lira-config.json \
+        -v "${LIRA_DIR}/kubernetes/${CAAS_ENVIRONMENT}-key.json":/etc/lira/${CAAS_ENVIRONMENT}-key.json \
         --name=lira \
-        $(echo "$mount_pipeline_tools" | xargs) \
-        $(echo "$mount_tenx" | xargs) \
-        $(echo "$mount_ss2" | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version
+        $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
+        $(echo ${MOUNT_TENX} | xargs) \
+        $(echo ${MOUNT_SS2} | xargs) \
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
 else
     docker run -d \
         -p 8080:8080 \
         -e lira_config=/etc/lira/lira-config.json \
-        -v ${LIRA_DIR}/kubernetes/lira-config.json:/etc/lira/lira-config.json \
+        -v "${LIRA_DIR}/kubernetes/lira-config.json":/etc/lira/lira-config.json \
         --name=lira \
-        $(echo "$mount_pipeline_tools" | xargs) \
-        $(echo "$mount_tenx" | xargs) \
-        $(echo "$mount_ss2" | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:$lira_image_version
+        $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
+        $(echo ${MOUNT_TENX} | xargs) \
+        $(echo ${MOUNT_SS2} | xargs) \
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
 fi
 
-printf "\nWaiting for Lira to finish start up\n"
+printf "Waiting for Lira to finish start up\n"
 sleep 3
 
 n=$(docker ps -f "name=lira" | wc -l)
-if [ $n -lt 2 ]; then
-    printf "\nLira container exited unexpectedly\n"
+if [ ${n} -lt 2 ]; then
+    printf "Lira container exited unexpectedly\n"
     exit 1
 fi
 
 set +e
 function stop_lira_on_error {
-  printf "\n\nStopping Lira\n"
+  printf '\e[1;34m%-6s\e[m\n' "Stopping Lira"
   docker stop lira
   docker rm -v lira
-  printf "\n\nTest failed!\n\n"
+  printf '\e[1;91m%-6s\e[m\n' "Test failed!"
   exit 1
 }
 trap "stop_lira_on_error" ERR
 
-# 8. Send in notifications
+# 9. Send in notifications
 
-if [ "$use_hmac" == "true" ]; then
-  printf "\n\nGetting hmac key\n"
+if [ "${USE_HMAC}" == "true" ]; then
+  printf "\nGetting hmac key\n"
   HMAC_KEY=$(docker run -i --rm \
-        -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
+        -e VAULT_TOKEN="$(cat ${VAULT_TOKEN_PATH})" \
         broadinstitute/dsde-toolbox \
-        vault read -field=current_key secret/dsde/mint/${ENV}/lira/hmac_keys)
+        vault read -field=current_key secret/dsde/mint/${LIRA_ENVIRONMENT}/lira/hmac_keys)
   AUTH_PARAMS="--hmac_key $HMAC_KEY --hmac_key_id current_key"
 else
-  printf "\n\nGetting notification token\n"
+  printf "\nGetting notification token\n"
   notification_token=$(docker run -i --rm \
-        -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
+        -e VAULT_TOKEN="$(cat ${VAULT_TOKEN_PATH})" \
         broadinstitute/dsde-toolbox \
-        vault read -field=notification_token secret/dsde/mint/${ENV}/lira/lira_secret)
+        vault read -field=notification_token secret/dsde/mint/${LIRA_ENVIRONMENT}/lira/lira_secret)
   AUTH_PARAMS="--query_param_token $notification_token"
 fi
 
-printf "\n\nSending in notifications\n"
+printf "\nSending in notifications\n"
 # Uses the docker image built from Dockerfile next to this script
-ss2_workflow_id=$(docker run --rm -v $script_dir:/app \
+SS2_WORKFLOW_ID=$(docker run --rm -v ${SCRIPT_DIR}:/app \
                     -e LIRA_URL="http://lira:8080/notifications" \
-                    -e NOTIFICATION=/app/ss2_notification_dss_${env}.json \
+                    -e NOTIFICATION=/app/ss2_notification_dss_${LIRA_ENVIRONMENT}.json \
                     --link lira:lira \
                     quay.io/humancellatlas/secondary-analysis-mintegration /app/send_notification.py \
-                    $(echo "$AUTH_PARAMS" | xargs))
+                    $(echo "${AUTH_PARAMS}" | xargs))
 
-printf "\nss2_workflow_id: $ss2_workflow_id"
+printf "\nSS2_WORKFLOW_ID: ${SS2_WORKFLOW_ID}"
 
-# 9. Poll for completion
-printf "\n\nAwaiting workflow completion\n"
+# 10. Poll for completion
+printf "\nAwaiting workflow completion\n"
 
 # Uses the docker image built from Dockerfile next to this script
-if [ $use_caas == "true" ]; then
-    docker run --rm -v $script_dir:/app \
-        -v ${LIRA_DIR}/kubernetes/caas_key.json:/etc/lira/caas_key.json \
-        -e WORKFLOW_IDS=$ss2_workflow_id \
+if [ ${USE_CAAS} == "true" ]; then
+    docker run --rm -v ${SCRIPT_DIR}:/app \
+        -v ${LIRA_DIR}/kubernetes/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+        -e WORKFLOW_IDS=${SS2_WORKFLOW_ID} \
         -e WORKFLOW_NAMES=ss2 \
-        -e CROMWELL_URL=https://cromwell.caas-dev.broadinstitute.org \
-        -e CAAS_KEY=/etc/lira/caas_key.json \
+        -e CROMWELL_URL=https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org \
+        -e CAAS_KEY=/etc/lira/${CAAS_ENVIRONMENT}-key.json \
         -e TIMEOUT_MINUTES=120 \
         -e PYTHONUNBUFFERED=0 \
         --link lira:lira \
         quay.io/humancellatlas/secondary-analysis-mintegration /app/await_workflow_completion.py
 
 else
-    export CROMWELL_USER=$(docker run -i --rm \
-        -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
-            broadinstitute/dsde-toolbox \
-            vault read -field=cromwell_user secret/dsde/mint/${ENV}/common/htpasswd)
+    export CROMWELL_USER="$(docker run -i --rm \
+                                       -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
+                                       broadinstitute/dsde-toolbox \
+                                       vault read -field=cromwell_user \
+                                                  secret/dsde/mint/${LIRA_ENVIRONMENT}/common/htpasswd)"
 
-    export CROMWELL_PASSWORD=$(docker run -i --rm \
-        -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
-        broadinstitute/dsde-toolbox \
-        vault read -field=cromwell_password secret/dsde/mint/${ENV}/common/htpasswd)
+    export CROMWELL_PASSWORD="$(docker run -i --rm \
+                                          -e VAULT_TOKEN=$(cat ${VAULT_TOKEN_PATH}) \
+                                          broadinstitute/dsde-toolbox \
+                                          vault read -field=cromwell_password \
+                                                     secret/dsde/mint/${LIRA_ENVIRONMENT}/common/htpasswd)"
 
-    docker run --rm -v $script_dir:/app \
-        -e WORKFLOW_IDS=$ss2_workflow_id \
+    docker run --rm -v "${SCRIPT_DIR}:/app" \
+        -e WORKFLOW_IDS="${SS2_WORKFLOW_ID}" \
         -e WORKFLOW_NAMES=ss2 \
-        -e CROMWELL_URL=https://cromwell.mint-${ENV}.broadinstitute.org \
-        -e CROMWELL_USER=$CROMWELL_USER \
-        -e CROMWELL_PASSWORD=$CROMWELL_PASSWORD \
+        -e CROMWELL_URL="https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \
+        -e CROMWELL_USER="${CROMWELL_USER}" \
+        -e CROMWELL_PASSWORD="${CROMWELL_PASSWORD}" \
         -e TIMEOUT_MINUTES=120 \
         -e PYTHONUNBUFFERED=0 \
         --link lira:lira \
@@ -454,8 +606,8 @@ else
 fi
 
 
-# 10. Stop Lira
-printf "\n\nStopping Lira\n"
+# 11. Stop Lira
+printf "\nStopping Lira\n"
 docker stop lira
 docker rm -v lira
-printf "\n\nTest succeeded!\n\n"
+printf "\nTest succeeded!\n"

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -133,7 +133,7 @@ VAULT_TOKEN_PATH=${12}
 SUBMIT_WDL_DIR=${13}
 USE_CAAS=${14}
 USE_HMAC=${15}
-COLLECTION_NAME=${16:-"lira-${LIRA_ENVIRONMENT}-workflows"}
+COLLECTION_NAME=${16:-"lira-${LIRA_ENVIRONMENT}"}
 
 WORK_DIR=$(pwd)
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

--- a/tests/integration_test/run_int_test_locally.sh
+++ b/tests/integration_test/run_int_test_locally.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 repo_root=$1
-vault_token_path=$2
+VAULT_TOKEN_PATH=${VAULT_TOKEN_PATH:-"${HOME}/.vault-token"}
 
 #env=$1
 #lira_mode=$2
@@ -24,7 +24,7 @@ script_dir=$repo_root/tests/integration_test
 bash $script_dir/integration_test.sh \
         "test" \
         "github" \
-        "master" \
+        "ra_update_to_caas_prod" \
         "github" \
         "master" \
         "github" \
@@ -33,7 +33,7 @@ bash $script_dir/integration_test.sh \
         "master" \
         $(tail -n+2 $script_dir/dss_staging_sub_ids.tsv | head -n1 | cut -f1) \
         $(tail -n+2 $script_dir/dss_staging_sub_ids.tsv | head -n1 | cut -f2) \
-        "$vault_token_path" \
+        "${VAULT_TOKEN_PATH}" \
         "" \
         "true" \
         "true"

--- a/tests/integration_test/run_int_test_locally.sh
+++ b/tests/integration_test/run_int_test_locally.sh
@@ -24,7 +24,7 @@ SCRIPT_DIR="${repo_root}/tests/integration_test"
 bash ${SCRIPT_DIR}/integration_test.sh \
         "test" \
         "github" \
-        "ra_update_to_caas_prod" \
+        "master" \
         "github" \
         "rex-rhian-testing" \
         "github" \

--- a/tests/integration_test/run_int_test_locally.sh
+++ b/tests/integration_test/run_int_test_locally.sh
@@ -26,7 +26,7 @@ bash ${SCRIPT_DIR}/integration_test.sh \
         "github" \
         "ra_update_to_caas_prod" \
         "github" \
-        "master" \
+        "rex-rhian-testing" \
         "github" \
         "master" \
         "github" \

--- a/tests/integration_test/run_int_test_locally.sh
+++ b/tests/integration_test/run_int_test_locally.sh
@@ -19,9 +19,9 @@ VAULT_TOKEN_PATH=${VAULT_TOKEN_PATH:-"${HOME}/.vault-token"}
 #use_caas=${14}
 #use_hmac=${15}
 
-script_dir=$repo_root/tests/integration_test
+SCRIPT_DIR="${repo_root}/tests/integration_test"
 
-bash $script_dir/integration_test.sh \
+bash ${SCRIPT_DIR}/integration_test.sh \
         "test" \
         "github" \
         "ra_update_to_caas_prod" \
@@ -31,8 +31,8 @@ bash $script_dir/integration_test.sh \
         "master" \
         "github" \
         "master" \
-        $(tail -n+2 $script_dir/dss_staging_sub_ids.tsv | head -n1 | cut -f1) \
-        $(tail -n+2 $script_dir/dss_staging_sub_ids.tsv | head -n1 | cut -f2) \
+        "$(tail -n+2 ${SCRIPT_DIR}/dss_staging_sub_ids.tsv | head -n1 | cut -f1)" \
+        "$(tail -n+2 ${SCRIPT_DIR}/dss_staging_sub_ids.tsv | head -n1 | cut -f2)" \
         "${VAULT_TOKEN_PATH}" \
         "" \
         "true" \

--- a/tests/integration_test/send_notification.py
+++ b/tests/integration_test/send_notification.py
@@ -27,6 +27,7 @@ def run(args):
         msg = 'Unexpected response code {0} when sending notification {1} to url {2}: \n{3}'
         raise ValueError(msg.format(response.status_code, args.notification, args.lira_url, response.text))
 
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--lira_url', default=os.environ.get('LIRA_URL', None))

--- a/tests/integration_test/ss2_notification_dss_test.json
+++ b/tests/integration_test/ss2_notification_dss_test.json
@@ -2,8 +2,8 @@
   "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
   "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c",
   "match": {
-    "bundle_uuid": "f4b1199a-5c72-4c20-ae42-54862b361a72",
-    "bundle_version": "2018-06-12T171819.193393Z"
+    "bundle_uuid": "b0157d28-b2d4-4430-acdb-5e0cb45a50b9",
+    "bundle_version": "2018-08-24T114140.659344Z"
   },
   "labels": {
     "mintegration-test": "true"

--- a/tests/load_test/README.md
+++ b/tests/load_test/README.md
@@ -21,7 +21,7 @@ This test suite has the following file structure:
 ```
 ├── README.md
 ├── data/  # This folder serves all data for performing a load test
-│   ├── lira_config/  # This folder serves the template file of listener config
+│   ├── lira_config/  # This folder serves the template file of lira config
 │   │   └── load_test_lira_config.json.ctmpl
 │   ├── plots/  # This folder is used to store metrics plots
 │   ├── notification/  # This folder serves the notification file for the test

--- a/tests/load_test/render_lira_config.sh
+++ b/tests/load_test/render_lira_config.sh
@@ -17,7 +17,7 @@ function render_lira_config(){
     local DRY_RUN=${2:-"false"}
     local VAULT_TOKEN_FILE=${3:-"$HOME/.vault-token"}
 
-    NOTIFICATION_TOKEN=$(docker run -it --rm -v ${VAULT_TOKEN_FILE}:/root/.vault-token broadinstitute/dsde-toolbox vault read -field=notification_token secret/dsde/mint/${ENV}/listener/listener_secret)
+    NOTIFICATION_TOKEN=$(docker run -it --rm -v ${VAULT_TOKEN_FILE}:/root/.vault-token broadinstitute/dsde-toolbox vault read -field=notification_token secret/dsde/mint/${ENV}/lira/lira_secret)
     CROMWELL_USERNAME=$(docker run -it --rm -v ${VAULT_TOKEN_FILE}:/root/.vault-token broadinstitute/dsde-toolbox vault read -field=cromwell_user secret/dsde/mint/${ENV}/common/htpasswd)
     CROMWELL_PASSWORD=$(docker run -it --rm -v ${VAULT_TOKEN_FILE}:/root/.vault-token broadinstitute/dsde-toolbox vault read -field=cromwell_password secret/dsde/mint/${ENV}/common/htpasswd)
 


### PR DESCRIPTION
Build the pipeline-tools image and push the image to quay before sending a notification to Lira to avoid the case where the image is not built by the time the mintegration test starts.

After this is merged, we will need to modify the build trigger for humancellatlas/secondary-analysis-pipeline-tools to remove the regex that matches branch names: `(heads/[a-zA-Z0-9][A-Za-z0-9_.-]+)`

Note: This is using the branch that fixes the mintegration test as the base branch to avoid merge conflicts. 