### PR TITLE
Fix failure analysis script

### DIFF
--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -17,6 +17,7 @@ import argparse
 import collections
 import arrow
 import requests
+import json
 from pipeline_tools import gcs_utils
 from cromwell_tools import cromwell_tools
 
@@ -200,7 +201,7 @@ def group_workflows_by_failed_task(workflows):
 
 
 def get_failure_message(task_metadata, record_std_err=True):
-    exception = task_metadata.get('failures')
+    exception = json.dumps(task_metadata.get('failures'))
     stderr_link = task_metadata.get('stderr')
     if stderr_link:
         file_contents = str(get_gcs_file(stderr_link))

--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -201,17 +201,21 @@ def group_workflows_by_failed_task(workflows):
 
 
 def get_failure_message(task_metadata, record_std_err=True):
-    exception = json.dumps(task_metadata.get('failures'))
+    failure_message = json.dumps(task_metadata.get('failures'))
     stderr_link = task_metadata.get('stderr')
     if stderr_link:
         file_contents = str(get_gcs_file(stderr_link))
         for error in ERRORS:
             if ERRORS[error] in file_contents:
-                exception = ERRORS[error]
-    if record_std_err:
-        with open('std_err.txt', 'a') as f:
-            f.write(exception + '\n')
-    return exception
+                failure_message = ERRORS[error]
+                break
+        else:
+            if record_std_err:
+                # Record the full std error for any exception that is not found in the `ERRORS` dict
+                print('Unknown exception, recording std error...')
+                with open('std_err.txt', 'a') as f:
+                    f.write(file_contents + '\n\n')
+    return failure_message
 
 
 def format_metadata_output(metadata, record_std_err):

--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -204,7 +204,7 @@ def get_failure_message(task_metadata, record_std_err=True):
     failure_message = json.dumps(task_metadata.get('failures'))
     stderr_link = task_metadata.get('stderr')
     if stderr_link:
-        file_contents = str(get_gcs_file(stderr_link))
+        file_contents = get_gcs_file(stderr_link).decode('utf-8')
         for error in ERRORS:
             if ERRORS[error] in file_contents:
                 failure_message = ERRORS[error]

--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -114,9 +114,9 @@ def parse_workflow(workflow_metadata, cromwell_url):
     bundle_id = workflow_metadata['labels']['bundle-uuid']
 
     parsed_meta = {
-        'name': workflow_metadata['workflowName'],
-        'submission': workflow_metadata['submission'],
-        'start': workflow_metadata['start'],
+        'name': workflow_metadata.get('workflowName'),
+        'submission': workflow_metadata.get('submission'),
+        'start': workflow_metadata.get('start'),
         'end': workflow_metadata.get('end'),
         'id': workflow_id,
         'status': workflow_metadata['status'],


### PR DESCRIPTION
This PR makes several improvements/fixes to recording workflow failures:
- Convert the failure metadata (which can be a list of failure objects) to JSON to prevent any errors with writing it out into a file
- If `record_stderr` is True, only record for errors that are not already included in the `ERRORS` map to better identify new errors
- Convert contents of stderr files to strings to improve formatting