### PR TITLE
Update test bundle

### DIFF
--- a/tests/integration_test/ss2_notification_dss_test.json
+++ b/tests/integration_test/ss2_notification_dss_test.json
@@ -2,8 +2,8 @@
   "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
   "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c",
   "match": {
-    "bundle_uuid": "b0157d28-b2d4-4430-acdb-5e0cb45a50b9",
-    "bundle_version": "2018-08-24T114140.659344Z"
+    "bundle_uuid": "1e6b07f4-48f8-472c-a676-692ac60baae5",
+    "bundle_version": "2018-10-04T214535.565796Z"
   },
   "labels": {
     "mintegration-test": "true"


### PR DESCRIPTION
Use a newer SS2 bundle since there is no longer a bundle manifest record for the previous bundle in the integration environment of ingest