### PR TITLE
Add Project UUID as a column to the CaaS Job Manager

### DIFF
--- a/deploy/job-manager/capabilities_config.json
+++ b/deploy/job-manager/capabilities_config.json
@@ -37,6 +37,11 @@
       "fieldType": "text"
     },
     {
+      "field": "labels.project_uuid",
+      "display": "Project UUID",
+      "fieldType": "text"
+    },
+    {
       "field": "labels.sample_id",
       "display": "Sample ID",
       "fieldType": "text"
@@ -63,7 +68,8 @@
     "comment",
     "submitter_id",
     "sample_id",
-    "project_shortname"
+    "project_shortname",
+    "project_uuid"
   ],
   "queryExtensions": []
 }

--- a/deploy/job-manager/capabilities_config_caas.json
+++ b/deploy/job-manager/capabilities_config_caas.json
@@ -42,6 +42,11 @@
       "fieldType": "text"
     },
     {
+      "field": "labels.project_uuid",
+      "display": "Project UUID",
+      "fieldType": "text"
+    },
+    {
       "field": "labels.sample_id",
       "display": "Sample ID",
       "fieldType": "text"
@@ -81,6 +86,7 @@
     "submitter_id",
     "sample_id",
     "project_shortname",
+    "project_uuid",
     "flag"
   ],
   "queryExtensions": [

--- a/deploy/job-manager/deploy.sh
+++ b/deploy/job-manager/deploy.sh
@@ -30,6 +30,7 @@ function configure_kubernetes() {
 
     stdout "Setting to use GKE cluster: project gke_${GCLOUD_PROJECT}_us-central1-b_lira"
     kubectl config use-context ${GKE_CONTEXT}
+    kubectl config set-context $(kubectl config current-context) --namespace=green-100-us-central1-ns
 }
 
 function create_API_config() {

--- a/deploy/job-manager/deploy.sh
+++ b/deploy/job-manager/deploy.sh
@@ -4,7 +4,7 @@
 # =======================================
 # Example Usage:
 # bash deploy.sh broad-dsde-mint-dev gke_broad-dsde-mint-dev_us-central1-b_lira v0.0.4 \
-# "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1" false true username password dev
+# "https://cromwell.mint-dev.broadinstitute.org/api/workflows/v1" false true username password dev "gcloud_client_id" "" "kube_cluster_namespace"
 # =======================================
 
 function line() {
@@ -24,13 +24,18 @@ function stderr() {
 function configure_kubernetes() {
     local GCLOUD_PROJECT=$1
     local GKE_CONTEXT=$2
+    local CLUSTER_NAMESPACE=$3
 
     stdout "Setting to use Google project: project ${GCLOUD_PROJECT}"
     gcloud config set project ${GCLOUD_PROJECT}
 
     stdout "Setting to use GKE cluster: project gke_${GCLOUD_PROJECT}_us-central1-b_lira"
     kubectl config use-context ${GKE_CONTEXT}
-    kubectl config set-context $(kubectl config current-context) --namespace=green-100-us-central1-ns
+
+    if [ -n ${CLUSTER_NAMESPACE} ]; then
+        kubectl config set-context $(kubectl config current-context) --namespace=${CLUSTER_NAMESPACE}
+    fi
+
 }
 
 function create_API_config() {
@@ -201,8 +206,9 @@ function main() {
     local JMUI_USR=$7
     local JMUI_PWD=$8
     local VAULT_ENV=$9
-    local CLIENT_ID=${10:-""}
+    local CLIENT_ID=${10:-"clientID_placeholder"}
     local VAULT_TOKEN_FILE=${11:-"$HOME/.vault-token"}
+    local CLUSTER_NAMESPACE=${12:-""}
 
     local DOCKER_TAG=${JMUI_TAG}
     local API_DOCKER_IMAGE="databiosphere/job-manager-api-cromwell:${DOCKER_TAG}"
@@ -211,7 +217,7 @@ function main() {
     set -e
 
     line
-    configure_kubernetes ${GCLOUD_PROJECT} ${GKE_CONTEXT}
+    configure_kubernetes ${GCLOUD_PROJECT} ${GKE_CONTEXT} ${CLUSTER_NAMESPACE}
 
     local API_CONFIG="cromwell-credentials-$(date '+%Y-%m-%d-%H-%M')"
     local JM_CONFIGMAP_OBJ="jm-configmap-$(date '+%Y-%m-%d-%H-%M')"
@@ -317,17 +323,21 @@ if [ -z $9 ]; then
 fi
 
 if [ -z ${10} ]; then
-    echo -e "\nYou must specify a Client ID if authentication is required in the capabilities config, using default value ''."
+    echo -e "\nYou must specify a Client ID if authentication is required in the capabilities config, using default value 'clientID_placeholder'."
 fi
 
 if [ -z ${11} ]; then
-    echo -e "\nMissing the Vault token file parameter, using default value $HOME/.vault-token. Otherwise, pass in the path to the token file as the 9th argument of this script!"
+    echo -e "\nMissing the Vault token file parameter, using default value $HOME/.vault-token. Otherwise, pass in the path to the token file as the 11th argument of this script!"
+fi
+
+if [ -z ${12} ]; then
+    echo -e "\nMissing the Kubernetes cluster namespace parameter, using the default namespace. Otherwise, pass in the string of namespace as the 12th argument of this script!"
 fi
 
 
 if [ $error -eq 1 ]; then
-    echo -e "\nUsage: bash deploy.sh GCLOUD_PROJECT GKE_CONTEXT JMUI_TAG CROMWELL_URL USE_CAAS USE_PROXY JMUI_USR JMUI_PWD VAULT_ENV(dev/staging/test) CLIENT_ID(optional) VAULT_TOKEN_FILE(optional)\n"
+    echo -e "\nUsage: bash deploy.sh GCLOUD_PROJECT GKE_CONTEXT JMUI_TAG CROMWELL_URL USE_CAAS USE_PROXY JMUI_USR JMUI_PWD VAULT_ENV(dev/staging/test) CLIENT_ID(optional) VAULT_TOKEN_FILE(optional) CLUSTER_NAMESPACE(optional)\n"
     exit 1
 fi
 
-main $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10} ${11}
+main $1 $2 $3 $4 $5 $6 $7 $8 $9 ${10:-"clientID_placeholder"} ${11:-"$HOME/.vault-token"} ${12}

--- a/tests/scale_test/analysis/failure_analysis.py
+++ b/tests/scale_test/analysis/failure_analysis.py
@@ -161,8 +161,8 @@ def parse_task(task_name, task_metadata, root_workflow_id, bundle_id):
         'status': task_metadata['executionStatus'],
         'failures': task_metadata.get('failures'),
         'attempt': task_metadata['attempt'],
-        'stdout': task_metadata['stdout'],
-        'stderr': task_metadata['stderr'],
+        'stdout': task_metadata.get('stdout'),
+        'stderr': task_metadata.get('stderr'),
         'bundle_id': bundle_id
     }
 
@@ -288,8 +288,8 @@ def main(cromwell_url, auth, headers, output_file, record_std_err=True, start=No
     with open(output_file, 'w') as f:
         f.write('Primary Bundle ID,Workflow ID,Workflow Status,Failed Task,Workflow Error\n')
         for each in workflow_data:
-            f.write('{},{},{},{},{}\n'.format(each['bundle_id'], each['id'], each['status'],
-                                              each['task_name'], each.get('error', '')))
+            f.write('{},{},{},{},{}\n'.format(each.get('bundle_id'), each.get('id'), each.get('status'),
+                                              each.get('task_name'), each.get('error', '')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/484.
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Add project-uuid as a new column to the CaaS Job Manager.
- Make the failure analysis script more corner-case resistant. Right now it will run into errors when there are missing keys.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
