### PR TITLE
Send lira logging output to shell script output so it can be seen in the build logs.

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -528,6 +528,8 @@ set +ex
 function stop_lira_on_error {
   print_style "error" "Stopping Lira"
   docker stop ${LIRA_DOCKER_CONTAINER_NAME}
+  print_style "error" "Lira Log:"
+  docker logs ${LIRA_DOCKER_CONTAINER_NAME}
   print_style "error" "Removing Lira"
   docker rm -v ${LIRA_DOCKER_CONTAINER_NAME}
   print_style "error" "Test failed!"

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -537,8 +537,9 @@ trap "stop_lira_on_error" ERR
 
 if [ ${USE_CAAS} ];
 then
-    print_style "info" "docker run -d \
+    print_style "info" "docker run \
         -p ${LIRA_HOST_PORT}:8080 \
+        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -e caas_key=/etc/lira/deploy/config_files/${CAAS_ENVIRONMENT}-key.json \
         -v ${LIRA_DIR}/deploy/config_files/lira-config.json:/etc/lira/lira-config.json \
@@ -547,10 +548,11 @@ then
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}"
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &"
 
-    docker run -d \
+    docker run \
         -p ${LIRA_HOST_PORT}:8080 \
+        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -e caas_key=/etc/lira/${CAAS_ENVIRONMENT}-key.json \
         -v "${LIRA_DIR}/deploy/config_files/lira-config.json":/etc/lira/lira-config.json \
@@ -559,28 +561,30 @@ then
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &
 
 else
-    print_style "info" "docker run -d \
+    print_style "info" "docker run \
         -p ${LIRA_HOST_PORT}:8080 \
+        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -v "${LIRA_DIR}/deploy/config_files/lira-config.json":/etc/lira/lira-config.json \
         --name=${LIRA_DOCKER_CONTAINER_NAME} \
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}"
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &"
 
-    docker run -d \
+    docker run \
         -p ${LIRA_HOST_PORT}:8080 \
+        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -v "${LIRA_DIR}/deploy/config_files/lira-config.json":/etc/lira/lira-config.json \
         --name="${LIRA_DOCKER_CONTAINER_NAME}" \
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &
 fi
 
 print_style "info" "Waiting for Lira to finish start up"

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -539,9 +539,8 @@ trap "stop_lira_on_error" ERR
 
 if [ ${USE_CAAS} ];
 then
-    print_style "info" "docker run \
+    print_style "info" "docker run -d \
         -p ${LIRA_HOST_PORT}:8080 \
-        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -e caas_key=/etc/lira/deploy/config_files/${CAAS_ENVIRONMENT}-key.json \
         -v ${LIRA_DIR}/deploy/config_files/lira-config.json:/etc/lira/lira-config.json \
@@ -550,11 +549,10 @@ then
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &"
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}"
 
-    docker run \
+    docker run -d \
         -p ${LIRA_HOST_PORT}:8080 \
-        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -e caas_key=/etc/lira/${CAAS_ENVIRONMENT}-key.json \
         -v "${LIRA_DIR}/deploy/config_files/lira-config.json":/etc/lira/lira-config.json \
@@ -563,30 +561,28 @@ then
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
 
 else
-    print_style "info" "docker run \
+    print_style "info" "docker run -d \
         -p ${LIRA_HOST_PORT}:8080 \
-        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -v "${LIRA_DIR}/deploy/config_files/lira-config.json":/etc/lira/lira-config.json \
         --name=${LIRA_DOCKER_CONTAINER_NAME} \
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &"
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}"
 
-    docker run \
+    docker run -d \
         -p ${LIRA_HOST_PORT}:8080 \
-        -a stdout -a stderr \
         -e lira_config=/etc/lira/lira-config.json \
         -v "${LIRA_DIR}/deploy/config_files/lira-config.json":/etc/lira/lira-config.json \
         --name="${LIRA_DOCKER_CONTAINER_NAME}" \
         $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
         $(echo ${MOUNT_TENX} | xargs) \
         $(echo ${MOUNT_SS2} | xargs) \
-        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION} &
+        quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE_VERSION}
 fi
 
 print_style "info" "Waiting for Lira to finish start up"


### PR DESCRIPTION
### Purpose

Add lira log output to the integration test output to help debugging errors in lira.

### Changes

- Lira logging output is sent to stdout, so it will appear in the build logs.

### Review Instructions

- Verify that the integration tests show Lira logging output

### PR Checklist

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

### Follow-up Discussions

- No follow-up discussions.
