### PR TITLE
Add sleep between notifications in Mintegration test.

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -626,6 +626,9 @@ SS2_WORKFLOW_ID=$(docker run --rm -v ${SCRIPT_DIR}:/app \
 
 print_style "info" "SS2_WORKFLOW_ID: ${SS2_WORKFLOW_ID}"
 
+# Make sure the Github won't refuse to establish connection with Lira
+sleep 10
+
 # Uses the docker image built from Dockerfile next to this script
 TENX_WORKFLOW_ID=$(docker run --rm -v ${SCRIPT_DIR}:/app \
                     -e LIRA_URL="http://lira:8080/notifications" \


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- Trying to resolve the issue with Lira fails to pull WDL from Github:
```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='raw.githubusercontent.com', port=443): Max retries exceeded with url: /HumanCellAtlas/pipeline-tools/master/adapter_pipelines/cellranger/adapter.wdl (Caused by NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7f4262c4c9b0>: Failed to establish a new connection: [Errno -3] Temporary failure in name resolution',))
```
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Add 10-second-sleep between notifications in Mintegration test.
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
