### PR TITLE
Update SS2 bundle used for integration test

### DIFF
--- a/tests/integration_test/ss2_notification_dss_test.json
+++ b/tests/integration_test/ss2_notification_dss_test.json
@@ -2,8 +2,8 @@
   "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
   "subscription_id": "dd17bb03-7634-47a4-9fd3-a55580ac3b1c",
   "match": {
-    "bundle_uuid": "1e6b07f4-48f8-472c-a676-692ac60baae5",
-    "bundle_version": "2018-10-04T214535.565796Z"
+    "bundle_uuid": "bab542a6-7625-49ad-bef5-954e11419cf1",
+    "bundle_version": "2019-02-05T230536.536155Z"
   },
   "labels": {
     "mintegration-test": "true"


### PR DESCRIPTION
### Purpose
Update the bundle used to test the SS2 pipeline in the integration environment. The current bundle cannot be used due to data consent issues.

---
### Changes
Updated SS2 bundle

---
### Review Instructions
- No instructions.

---
### PR Checklist
- [x] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
