### PR TITLE
Update 10x bundle used for testing

### DIFF
--- a/tests/integration_test/10x_notification_dss_test.json
+++ b/tests/integration_test/10x_notification_dss_test.json
@@ -2,8 +2,8 @@
   "transaction_id": "eed1414b-4e70-45a3-b6d1-7ec19ce5b666",
   "subscription_id": "513a39a6-eb65-450b-ba5f-ce50f56c42d4",
   "match": {
-    "bundle_uuid": "3eebea0c-8b80-4007-a860-6802a215276d",
-    "bundle_version": "2018-10-05T145809.216048Z"
+    "bundle_uuid": "ca6ea399-7ddf-46e6-a904-4d5f02025231",
+    "bundle_version": "2019-02-22T222251.233303Z"
   },
   "labels": {
     "mintegration-test": "true"


### PR DESCRIPTION
### Purpose
When the 10x query becomes more specific, the test bundle that the mintegration test uses will need to match on the new fields. 

Related to: https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/398

---
### Changes
Use a 10x bundle that includes a "3 prime tag" end bias and a "single cell" nucleic acid source to match the more specific 10x query.

---
### Review Instructions
This bundle should match the new [10x subscription query](https://github.com/HumanCellAtlas/lira/blob/master/scripts/vx_queries/10x-query.json) but still work for the current one as well: https://github.com/HumanCellAtlas/lira/blob/v0.17.0/scripts/vx_queries/10x-query.json

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
