### PR TITLE
Fix docker tag for built Lira image

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -335,7 +335,7 @@ function build_lira {
             export LIRA_IMAGE=${LIRA_VERSION}
         fi
 
-        docker build -t quay.io/humancellatlas/lira:${LIRA_IMAGE} .
+        docker build -t quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE} .
     fi
     
     cd "${WORK_DIR}/${TEMP_DIR}"

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -168,6 +168,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 GCLOUD_PROJECT=${GCLOUD_PROJECT:-"broad-dsde-mint-${LIRA_ENVIRONMENT}"} # other envs - broad-dsde-mint-test, broad-dsde-mint-staging, hca-dcp-pipelines-prod
 
+LIRA_DOCKER_REPO="quay.io/humancellatlas/secondary-analysis-lira"
+
 CAAS_ENVIRONMENT="caas-prod"
 LIRA_CONFIG_FILE="lira-config.json"
 
@@ -319,7 +321,7 @@ function build_lira {
             export LIRA_IMAGE=${LIRA_VERSION}
         fi
 
-        docker pull quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE}
+        docker pull ${LIRA_DOCKER_REPO}:${LIRA_IMAGE}
 
     elif [ "${LIRA_MODE}" == "local" ] || [ ${LIRA_MODE} == "github" ];
     then
@@ -335,7 +337,7 @@ function build_lira {
             export LIRA_IMAGE=${LIRA_VERSION}
         fi
 
-        docker build -t quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE} .
+        docker build -t ${LIRA_DOCKER_REPO}:${LIRA_IMAGE} .
     fi
     
     cd "${WORK_DIR}/${TEMP_DIR}"
@@ -489,7 +491,7 @@ function start_lira {
             $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
             $(echo ${MOUNT_TENX} | xargs) \
             $(echo ${MOUNT_SS2} | xargs) \
-            quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE}"
+            ${LIRA_DOCKER_REPO}:${LIRA_IMAGE}"
 
         docker run -d \
             -p ${LIRA_HOST_PORT}:8080 \
@@ -501,7 +503,7 @@ function start_lira {
             $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
             $(echo ${MOUNT_TENX} | xargs) \
             $(echo ${MOUNT_SS2} | xargs) \
-            quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE}
+            ${LIRA_DOCKER_REPO}:${LIRA_IMAGE}
     else
         print_style "info" "docker run -d \
             -p ${LIRA_HOST_PORT}:8080 \
@@ -511,7 +513,7 @@ function start_lira {
             $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
             $(echo ${MOUNT_TENX} | xargs) \
             $(echo ${MOUNT_SS2} | xargs) \
-            quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE}"
+            ${LIRA_DOCKER_REPO}:${LIRA_IMAGE}"
 
         docker run -d \
             -p ${LIRA_HOST_PORT}:8080 \
@@ -521,7 +523,7 @@ function start_lira {
             $(echo ${MOUNT_PIPELINE_TOOLS} | xargs) \
             $(echo ${MOUNT_TENX} | xargs) \
             $(echo ${MOUNT_SS2} | xargs) \
-            quay.io/humancellatlas/secondary-analysis-lira:${LIRA_IMAGE}
+            ${LIRA_DOCKER_REPO}:${LIRA_IMAGE}
     fi
 
     print_style "info" "Waiting for Lira to finish start up"


### PR DESCRIPTION
### Purpose
When the Lira docker image is built from the code on Github (instead of using an existing image) it is tagged with "quay.io/humancellatlas/lira", but the name of the repository is "[quay.io/humancellatlas/secondary-analysis-lira](https://quay.io/repository/humancellatlas/secondary-analysis-lira)" (which is used throughout the script).

This means that when the Lira image "quay.io/humancellatlas/secondary-analysis-lira" is run in the test it is not the same image that was built and tagged earlier.

This issue was observed when running the integration test using the master branch of Lira. Since I had an older image for "quay.io/humancellatlas/secondary-analysis-lira:master" on my computer, the test used that image instead of the one built with the new code on master.

---
### Changes
Change the docker tag used for the built Lira image so that it is `quay.io/humancellatlas/secondary-analysis-lira`

---
### Review Instructions
- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
