### PR TITLE
Run cromwell-tools commands in docker

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -597,7 +597,6 @@ function send_ss2_notification {
                                               vault read -field=cromwell_password \
                                                          secret/dsde/mint/${LIRA_ENVIRONMENT}/common/htpasswd)"
         docker run --rm \
-            -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
             quay.io/broadinstitute/cromwell-tools:v1.1.1 \
             cromwell-tools wait "${SS2_WORKFLOW_ID}" \
                 --username "${CROMWELL_USER}" \
@@ -665,7 +664,6 @@ function send_10x_notification {
                                               vault read -field=cromwell_password \
                                                          secret/dsde/mint/${LIRA_ENVIRONMENT}/common/htpasswd)"
         docker run --rm \
-            -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
             quay.io/broadinstitute/cromwell-tools:v1.1.1 \
             cromwell-tools wait "${TENX_WORKFLOW_ID}" \
                 --username "${CROMWELL_USER}" \

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -603,7 +603,7 @@ function send_ss2_notification {
                 --username "${CROMWELL_USER}" \
                 --password "${CROMWELL_PASSWORD}" \
                 --url "https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \
-                --timeout-minutes 120 \
+                --timeout-minutes 120
 
     fi
 }
@@ -667,7 +667,7 @@ function send_10x_notification {
         docker run --rm \
             -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
             quay.io/broadinstitute/cromwell-tools:v1.1.1 \
-            cromwell-tools wait "${SS2_WORKFLOW_ID}" \
+            cromwell-tools wait "${TENX_WORKFLOW_ID}" \
                 --username "${CROMWELL_USER}" \
                 --password "${CROMWELL_PASSWORD}" \
                 --url "https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \

--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -576,10 +576,13 @@ function send_ss2_notification {
 
     if [ "${USE_CAAS}" == "true" ];
     then
-        cromwell-tools wait "${SS2_WORKFLOW_ID}" \
-            --url "https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org" \
-            --service-account-key ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json \
-            --timeout-minutes 120
+        docker run --rm \
+            -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+            quay.io/broadinstitute/cromwell-tools:v1.1.1 \
+            cromwell-tools wait "${SS2_WORKFLOW_ID}" \
+                --url "https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org" \
+                --service-account-key /etc/lira/${CAAS_ENVIRONMENT}-key.json \
+                --timeout-minutes 120
 
     else
         export CROMWELL_USER="$(docker run -i --rm \
@@ -593,12 +596,14 @@ function send_ss2_notification {
                                               broadinstitute/dsde-toolbox \
                                               vault read -field=cromwell_password \
                                                          secret/dsde/mint/${LIRA_ENVIRONMENT}/common/htpasswd)"
-
-        cromwell-tools wait "${SS2_WORKFLOW_ID}" \
-            --username "${CROMWELL_USER}" \
-            --password "${CROMWELL_PASSWORD}" \
-            --url "https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \
-            --timeout-minutes 120 \
+        docker run --rm \
+            -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+            quay.io/broadinstitute/cromwell-tools:v1.1.1 \
+            cromwell-tools wait "${SS2_WORKFLOW_ID}" \
+                --username "${CROMWELL_USER}" \
+                --password "${CROMWELL_PASSWORD}" \
+                --url "https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \
+                --timeout-minutes 120 \
 
     fi
 }
@@ -639,10 +644,13 @@ function send_10x_notification {
 
     if [ "${USE_CAAS}" == "true" ];
     then
-        cromwell-tools wait "${TENX_WORKFLOW_ID}" \
-            --url "https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org" \
-            --service-account-key ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json \
-            --timeout-minutes 120
+        docker run --rm \
+            -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+            quay.io/broadinstitute/cromwell-tools:v1.1.1 \
+            cromwell-tools wait "${TENX_WORKFLOW_ID}" \
+                --url "https://cromwell.${CAAS_ENVIRONMENT}.broadinstitute.org" \
+                --service-account-key ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json \
+                --timeout-minutes 120
 
     else
         export CROMWELL_USER="$(docker run -i --rm \
@@ -656,12 +664,14 @@ function send_10x_notification {
                                               broadinstitute/dsde-toolbox \
                                               vault read -field=cromwell_password \
                                                          secret/dsde/mint/${LIRA_ENVIRONMENT}/common/htpasswd)"
-
-        cromwell-tools wait "${SS2_WORKFLOW_ID}" \
-            --username "${CROMWELL_USER}" \
-            --password "${CROMWELL_PASSWORD}" \
-            --url "https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \
-            --timeout-minutes 60
+        docker run --rm \
+            -v ${CONFIG_DIR}/${CAAS_ENVIRONMENT}-key.json:/etc/lira/${CAAS_ENVIRONMENT}-key.json \
+            quay.io/broadinstitute/cromwell-tools:v1.1.1 \
+            cromwell-tools wait "${SS2_WORKFLOW_ID}" \
+                --username "${CROMWELL_USER}" \
+                --password "${CROMWELL_PASSWORD}" \
+                --url "https://cromwell.mint-${LIRA_ENVIRONMENT}.broadinstitute.org" \
+                --timeout-minutes 120
     fi
 }
 


### PR DESCRIPTION
### Purpose
Instead of installing cromwell-tools in Jenkins, it is simpler to use the cromwell-tools docker
image to run the commands in the test.

---
### Changes
Use the cromwell-tools docker image to run the commands in the test.

---
### Review Instructions
This change can be tested locally:

1. Clone https://github.com/HumanCellAtlas/secondary-analysis
2. Check out this branch (se-fix-running-cromwell-tools)
3. Run bash run_int_test_locally.sh <path_to_cloned_secondary_analysis_repo> <path_to_vault_token>
4. Confirm that the test outputs a SS2_WORKFLOW_ID and that it is Awaiting workflow completion

---
### PR Checklist
- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
