### PR TITLE
Use https endpoint for metadata schemas

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -224,7 +224,7 @@ then
     INGEST_URL="https://api.ingest.data.humancellatlas.org/"
 else
     DSS_URL="https://dss.${ENV}.data.humancellatlas.org/v1"
-    SCHEMA_URL="http://schema.${ENV}.data.humancellatlas.org/"
+    SCHEMA_URL="https://schema.${ENV}.data.humancellatlas.org/"
     INGEST_URL="https://api.ingest.${ENV}.data.humancellatlas.org/"
 fi
 


### PR DESCRIPTION
### Purpose
Use https endpoint for metadata schemas to avoid ingest validation errors.

---
### Changes
Use https endpoint for metadata schemas to avoid ingest validation errors.

---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied Python style guidelines, specifically followed [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) for this repo.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
