### PR TITLE
add 'date' fieldType to enable mouseover behavior on job list

### DIFF
--- a/deploy/job-manager/capabilities_config_caas.json
+++ b/deploy/job-manager/capabilities_config_caas.json
@@ -16,11 +16,13 @@
     },
     {
       "field": "submission",
-      "display": "Submitted"
+      "display": "Submitted",
+      "fieldType": "date"
     },
     {
       "field": "end",
-      "display": "End Time"
+      "display": "End Time",
+      "fieldType": "date"
     },
     {
       "field": "labels.workflow-version",


### PR DESCRIPTION
Change to caas capabilities config to take advantage of special behavior of fields of type `date` on Job Manager job list screen.