### PR TITLE
add force flag

### DIFF
--- a/tests/integration_test/integration_test.sh
+++ b/tests/integration_test/integration_test.sh
@@ -489,7 +489,8 @@ function get_optimus_analysis_pipeline {
                         \"${OPTIMUS_PREFIX}/library/tasks/RunEmptyDrops.wdl\",
                         \"${OPTIMUS_PREFIX}/library/tasks/ZarrUtils.wdl\",
                         \"${OPTIMUS_PREFIX}/library/tasks/Picard.wdl\",
-                        \"${OPTIMUS_PREFIX}/library/tasks/UmiCorrection.wdl\"
+                        \"${OPTIMUS_PREFIX}/library/tasks/UmiCorrection.wdl\",
+                        \"${OPTIMUS_PREFIX}/library/tasks/ScatterBam.wdl\"
                     ]"
     export OPTIMUS_OPTIONS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/Optimus/options.json"
     export OPTIMUS_WDL_STATIC_INPUTS_LINK="${PIPELINE_TOOLS_PREFIX}/adapter_pipelines/Optimus/adapter_example_static.json"

--- a/tests/scale_test/notifier.py
+++ b/tests/scale_test/notifier.py
@@ -138,13 +138,21 @@ def cli():
     help='The path to the folder to save metrics of this notifier.',
     show_default=True,
 )
+@click.option(
+    '--force/--no-force',
+    default=False,
+    help='Whether or not to force analysis when a workflow with functionally '
+    'equivalent metadata already exists',
+    show_default=True,
+)
 @click.pass_context
-def notify(ctx, lira_url, label, workflow_name, es_query_path, save_path):
+def notify(ctx, lira_url, label, workflow_name, es_query_path, save_path, force):
     ctx.obj['lira_url'] = utils.harmonize_url(lira_url)
     ctx.obj['label'] = utils.compose_label(label)
     ctx.obj['workflow_name'] = workflow_name
     ctx.obj['es_query_path'] = es_query_path
     ctx.obj['save_path'] = save_path
+    ctx.obj['force'] = force
 
 
 @notify.command(
@@ -171,6 +179,11 @@ def once(ctx, uuid, version):
         ctx.obj['workflow_name'],
         ctx.obj['es_query_path'],
     )
+    if ctx.obj['force']:
+        if label is None:
+            label = {'force': None}
+        else:
+            label['force'] = None
 
     # Print the information of Lira
     logging.info('Talking to Lira instance: {}'.format(lira_url))

--- a/tests/scale_test/notifier.py
+++ b/tests/scale_test/notifier.py
@@ -141,8 +141,7 @@ def cli():
 @click.option(
     '--force/--no-force',
     default=False,
-    help='Whether or not to force analysis when a workflow with functionally '
-    'equivalent metadata already exists',
+    help='True to re-analyze data even though its functional equivalent exists already.',
     show_default=True,
 )
 @click.pass_context


### PR DESCRIPTION
### Purpose
<!-- Please explain the purpose of this PR and include links to any GitHub issues that it fixes: -->

Adding force flag to enable resubmission of failed workflows when falcon prevents analysis runs with functionally equivalent metadata
[JIRA](https://broadinstitute.atlassian.net/browse/GH-198)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

Add force flag which adds force label to downstream workflow

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
