### PR TITLE
Add force label for batch notify

### DIFF
--- a/tests/scale_test/notifier.py
+++ b/tests/scale_test/notifier.py
@@ -172,9 +172,9 @@ def once(ctx, uuid, version):
     )
     if ctx.obj['force']:
         if label is None:
-            label = {'force': None}
+            label = {'force': 'true'}
         else:
-            label['force'] = None
+            label['force'] = 'true'
 
     # Print the information of Lira
     logging.info('Talking to Lira instance: {}'.format(lira_url))
@@ -250,9 +250,9 @@ def batch(ctx, bundle_list_file, run_mode):
 
     if ctx.obj['force']:
         if label is None:
-            label = {'force': None}
+            label = {'force': 'true'}
         else:
-            label['force'] = None
+            label['force'] = 'true'
 
     # Print the information of Lira
     logging.info('Talking to Lira instance: {}'.format(lira_url))

--- a/tests/scale_test/notifier.py
+++ b/tests/scale_test/notifier.py
@@ -248,6 +248,12 @@ def batch(ctx, bundle_list_file, run_mode):
         ctx.obj['save_path'],
     )
 
+    if ctx.obj['force']:
+        if label is None:
+            label = {'force': None}
+        else:
+            label['force'] = None
+
     # Print the information of Lira
     logging.info('Talking to Lira instance: {}'.format(lira_url))
 


### PR DESCRIPTION
### Purpose
When using the notifier, the `force` option only works when sending in one notification with the `once` command. 

### Changes
Check for the `force` option in batch mode as well

### Review Instructions
- No instructions.
