### PR TITLE
Fix optimus mintegration test

### DIFF
--- a/tests/integration/integration_test.sh
+++ b/tests/integration/integration_test.sh
@@ -508,7 +508,9 @@ function get_optimus_analysis_pipeline {
                         \"${OPTIMUS_PREFIX}/library/tasks/ZarrUtils.wdl\",
                         \"${OPTIMUS_PREFIX}/library/tasks/Picard.wdl\",
                         \"${OPTIMUS_PREFIX}/library/tasks/UmiCorrection.wdl\",
-                        \"${OPTIMUS_PREFIX}/library/tasks/ScatterBam.wdl\"
+                        \"${OPTIMUS_PREFIX}/library/tasks/ScatterBam.wdl\",
+                        \"${OPTIMUS_PREFIX}/library/tasks/ModifyGtf.wdl\",
+                        \"${OPTIMUS_PREFIX}/library/tasks/OptimusInputChecks.wdl\"
                     ]"
     export OPTIMUS_OPTIONS_LINK="${ADAPTER_PIPELINES_PREFIX}/pipelines/optimus/options.json"
     export OPTIMUS_WDL_STATIC_INPUTS_LINK="${ADAPTER_PIPELINES_PREFIX}/pipelines/optimus/static_inputs.json"

--- a/tests/integration/optimus_notification_dss_integration.json
+++ b/tests/integration/optimus_notification_dss_integration.json
@@ -7,6 +7,7 @@
   },
   "labels": {
     "mintegration-test": "true",
-    "comment": "mintegration-test"
+    "comment": "mintegration-test",
+    "force": "true"
   }
 }


### PR DESCRIPTION
### Purpose
Fix the mintegration test for Optimus

### Changes
- Add the `force` flag to the notification so that Falcon does not abort the test workflow 
- Add missing imports for Optimus

### Review Instructions
- No instructions.
